### PR TITLE
Avoid duplicate rules in the iptables ruleset for the same timestamp

### DIFF
--- a/server/fw_util_iptables.h
+++ b/server/fw_util_iptables.h
@@ -35,11 +35,11 @@
 
 /* iptables command args
 */
-#define IPT_ADD_RULE_ARGS       "-t %s -A %s -p %i -s %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s 2>&1"
-#define IPT_ADD_OUT_RULE_ARGS   "-t %s -A %s -p %i -d %s --sport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s 2>&1"
-#define IPT_ADD_FWD_RULE_ARGS   "-t %s -A %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s 2>&1"
-#define IPT_ADD_DNAT_RULE_ARGS  "-t %s -A %s -p %i -s %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s --to-destination %s:%i 2>&1"
-#define IPT_ADD_SNAT_RULE_ARGS  "-t %s -A %s -p %i -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s %s 2>&1"
+#define IPT_RULE_ARGS           "-t %s -p %i -s %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s 2>&1"
+#define IPT_OUT_RULE_ARGS       "-t %s -p %i -d %s --sport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s 2>&1"
+#define IPT_FWD_RULE_ARGS       "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s 2>&1"
+#define IPT_DNAT_RULE_ARGS      "-t %s -p %i -s %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s --to-destination %s:%i 2>&1"
+#define IPT_SNAT_RULE_ARGS      "-t %s -p %i -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s %s 2>&1"
 #define IPT_TMP_COMMENT_ARGS    "-t %s -I %s %i -s 127.0.0.2 -m comment --comment " TMP_COMMENT " -j %s 2>&1"
 #define IPT_DEL_RULE_ARGS       "-t %s -D %s %i 2>&1"
 #define IPT_NEW_CHAIN_ARGS      "-t %s -N %s 2>&1"


### PR DESCRIPTION
I have played with fwknop on android and it works fine. Here is a part of my 
iptables ruleset dump after sending multiple packets

```
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764373 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764374 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764374 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764374 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764374 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764374 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764374 */
     0     0 ACCEPT     tcp  --  any    any     192.168.1.14 \
anywhere             tcp dpt:ssh /* _exp_1357764375 */
```

Using the check option (-C) from iptables will allow fwknop to make sure not to insert duplicate rule (same timestamp). However, I do see any way to avoid adding the same access rule with different timestamps.
