### PR TITLE
Allow the Python binding to build without prior installation of libfko

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -16,6 +16,8 @@ from distutils.core import setup, Extension
 fko_ext = Extension(
     '_fko',
     define_macros = [('MAJOR_VERSION', '1'), ('MINOR_VERSION', '5')],
+                    include_dirs = ['../lib/'],
+                    library_dirs = ['../lib/.libs'],
                     libraries = ['fko'],
                     sources = ['fkomodule.c']
 )


### PR DESCRIPTION
In order to build the Python binding for Debian, I had to update setup.py to find the libfko header and libfko soname in the build env as previously done for the libfko-perl package. I cannot installed the libfko when trying to build the Python binding, this is the reason of these changes.

I have checked and I am also able to build the Python binding with libfko-dev installed on my Debian system.

I can add the changes as a patch in my Debian build, but if you think it is worth merging it to your sources, please do so.

Regards,
