### PR TITLE
[FTBS] Fixed gpl2.0.texi

### DIFF
--- a/doc/gpl-2.0.texi
+++ b/doc/gpl-2.0.texi
@@ -17,7 +17,7 @@ Everyone is permitted to copy and distribute verbatim copies
 of this license document, but changing it is not allowed.
 @end display
 
-@appendixsubsec Preamble
+@appendixsec Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -68,7 +68,7 @@ patent must be licensed for everyone's free use or not licensed at all.
 modification follow.
 
 @iftex
-@appendixsubsec TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+@appendixsec TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 @end iftex
 @ifinfo
 @center GNU GENERAL PUBLIC LICENSE
@@ -333,7 +333,7 @@ POSSIBILITY OF SUCH DAMAGES.
 @end ifinfo
 
 @page
-@appendixsubsec Appendix: How to Apply These Terms to Your New Programs
+@appendixsec Appendix: How to Apply These Terms to Your New Programs
 
   If you develop a new program, and you want it to be of the greatest
 possible use to the public, the best way to achieve this is to make it


### PR DESCRIPTION
The @appendixsubsec entries are substituted by @appendixsec entries.

This fixes the Debian issue in sid. The report can be found at 

http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=708589

```
./gpl-2.0.texi:20: raising the section level of @appendixsubsec which is too low
```
