### PR TITLE
Do not assume blank line between stanza in rc files

### DIFF
--- a/client/config_init.c
+++ b/client/config_init.c
@@ -1254,13 +1254,15 @@ update_rc(fko_cli_options_t *options, uint32_t args_bitmask)
     {
         /* but the stanza has been found, We update it now. */
         if (stanza_found == 1)
-            log_msg(LOG_VERBOSITY_DEBUG, "update_rc() : Updating %s stanza", curr_stanza);
+            log_msg(LOG_VERBOSITY_DEBUG, "update_rc() : Updating %s stanza",
+                    options->use_rc_stanza);
 
         /* otherwise we append the new settings to the file */
         else
         {
             fprintf(rc_update, "\n");
-            log_msg(LOG_VERBOSITY_DEBUG, "update_rc() : Inserting new %s stanza", curr_stanza);
+            log_msg(LOG_VERBOSITY_DEBUG, "update_rc() : Inserting new %s stanza",
+                    options->use_rc_stanza);
             fprintf(rc_update, RC_SECTION_TEMPLATE, options->use_rc_stanza);
         }
 


### PR DESCRIPTION
Hi Michael,

The pull request should fixed the issue mrash/fwknop#81. Please give it a try.

I have noticed the following command line produces two failed tests.

```
 ./test-fwknop.pl --loopback lo --enable-all --include "rc file default key, rc file named key"
```

but I am not sure to understand what is going on.
