### PR TITLE
Support for "--no-save-args" in .fwknoprc

### DIFF
--- a/client/config_init.c
+++ b/client/config_init.c
@@ -862,6 +862,7 @@ create_fwknoprc(const char *rcfile)
         "#GPG_EXE             /path/to/gpg\n"
         "#GPG_SIGNER          <signer ID>\n"
         "#GPG_RECIPIENT       <recipient ID>\n"
+		"#NO_SAVE_ARGS        N\n"
         "\n"
         "# User-provided named stanzas:\n"
         "\n"


### PR DESCRIPTION
Honestly I didn't check open issues or which is the best branch to implement it :-(

I just wanted to avoid creating .fwknop.run by default...

btw. I like fwknop, nice work!
