### PR TITLE
android: allow definition of custom server udp port

### DIFF
--- a/android/project/jni/fwknop/fwknop_client.c
+++ b/android/project/jni/fwknop/fwknop_client.c
@@ -68,6 +68,10 @@ jstring Java_com_max2idea_android_fwknop_Fwknop_sendSPAPacket(JNIEnv* env,
     jstring jdestip = (*env)->GetObjectField(env, thiz, fid);
     const char *destip_str = (*env)->GetStringUTFChars(env, jdestip, 0);
 
+    fid = (*env)->GetFieldID(env, c, "destport_str", "Ljava/lang/String;");
+    jstring jdestport = (*env)->GetObjectField(env, thiz, fid);
+    const char *destport_str = (*env)->GetStringUTFChars(env, jdestport, 0);
+
     fid = (*env)->GetFieldID(env, c, "passwd_str", "Ljava/lang/String;");
     jstring jpasswd = (*env)->GetObjectField(env, thiz, fid);
     const char *passwd_str = (*env)->GetStringUTFChars(env, jpasswd, 0);
@@ -94,6 +98,10 @@ jstring Java_com_max2idea_android_fwknop_Fwknop_sendSPAPacket(JNIEnv* env,
         sprintf(res_msg, "Error: Invalid or missing destination IP");
         goto cleanup2;
     }
+    if(destport_str == NULL) {
+        sprintf(res_msg, "Error: Invalid or missing destination port");
+        goto cleanup2;
+    }
     if(passwd_str == NULL) {
         sprintf(res_msg, "Error: Invalid or missing password");
         goto cleanup2;
@@ -112,7 +120,7 @@ jstring Java_com_max2idea_android_fwknop_Fwknop_sendSPAPacket(JNIEnv* env,
     /* Set our spa server info
     */
     opts.spa_server_str = (char*)destip_str;
-    opts.spa_dst_port   = FKO_DEFAULT_PORT; /* Until we make this settable. */
+    opts.spa_dst_port   = atoi(destport_str);
 
     /* Intialize the context
     */

--- a/android/project/res/layout/main.xml
+++ b/android/project/res/layout/main.xml
@@ -88,6 +88,27 @@
             android:textSize="20dip"
             />
     </LinearLayout>
+    <LinearLayout android:id="@+id/destPortl"
+        android:orientation="horizontal"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        >
+        <TextView
+            android:id="@+id/destPortStr"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Server UDP Port: "
+            android:textSize="20dip"
+            />
+        <EditText
+            android:id="@+id/destPort"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:text="62201"
+            android:singleLine="true"
+            android:textSize="20dip"
+            />
+    </LinearLayout>
     <LinearLayout android:id="@+id/fwTimeoutl"
                   android:orientation="horizontal"
                   android:layout_width="fill_parent"

--- a/android/project/src/com/max2idea/android/fwknop/Fwknop.java
+++ b/android/project/src/com/max2idea/android/fwknop/Fwknop.java
@@ -98,6 +98,7 @@ public class Fwknop extends Activity {
     private EditText mPasswd;
     private EditText mHmac;
     private EditText mDestip;
+    private EditText mDestport;
     private EditText mTCPAccessPorts;
     private EditText mUDPAccessPorts;
     private EditText mFwTimeout;
@@ -107,6 +108,7 @@ public class Fwknop extends Activity {
     private String passwd_str;
     private String hmac_str;
     private String destip_str;
+    private String destport_str;
     private String fw_timeout_str;
     private CheckBox mCheck;
     private String externalIP = "";
@@ -344,6 +346,14 @@ public class Fwknop extends Activity {
             return;
         }
 
+        if (this.mDestport != null && !this.mDestport.getText().toString().trim().equals("")) {
+            this.destport_str = mDestport.getText().toString();
+            edit.putString("destport_str", mDestport.getText().toString());
+        } else {
+            this.UIAlert("Input error", "Please enter a valid Server port", this);
+            return;
+        }
+
         if (this.mFwTimeout != null) {
             int fw_timeout;
             try {
@@ -380,6 +390,9 @@ public class Fwknop extends Activity {
 
         this.mDestip = (EditText) findViewById(R.id.destIP);
         this.mDestip.setText(prefs.getString("destip_str", ""));
+
+        this.mDestport = (EditText) findViewById(R.id.destPort);
+        this.mDestport.setText(prefs.getString("destport_str", "62201"));
 
         this.mFwTimeout = (EditText) findViewById(R.id.fwTimeout);
         this.mFwTimeout.setText(prefs.getString("fw_timeout_str", "60"));


### PR DESCRIPTION
This adds a "Server UDP Port" setting just below "Server Address". It allows the user to change the port the SPA packet is sent to.