### PR TITLE
server: remove extra '/run' subdir from paths 

### DIFF
--- a/doc/fwknopd.man.asciidoc
+++ b/doc/fwknopd.man.asciidoc
@@ -68,7 +68,7 @@ COMMAND-LINE OPTIONS
 *-d, --digest-file*='<digest-file>'::
     Specify the location of the 'digest.cache' file. If this option is
     not given, 'fwknopd' will use the compile-time default location (typically
-    '@localstatedir@/run/fwknop/digest.cache').
+    '@localstatedir@/fwknop/digest.cache').
 
 *-D, --dump-config*::
     Dump the configuration values that *fwknopd* derives from the
@@ -131,7 +131,7 @@ COMMAND-LINE OPTIONS
 *-p, --pid-file*='<pid-file>'::
     Specify the location of the 'fwknopd.pid' file. If this option is
     not given, 'fwknopd' will use the compile-time default location (typically
-    '@localstatedir@/run/fwknop/fwknopd.pid).
+    '@localstatedir@/fwknop/fwknopd.pid).
 
 *-P, --pcap-filter*='<filter>'::
     Specify a Berkeley packet filter statement on the *fwknopd* command
@@ -165,11 +165,11 @@ COMMAND-LINE OPTIONS
 *--rotate-digest-cache*::
     Rotate the digest cache file by renaming it to ``<name>-old'', and
     starting a new one. The digest cache file is typically found in
-    '@localstatedir@/run/fwknop/digest.cache'.
+    '@localstatedir@/fwknop/digest.cache'.
 
 *-r, --run-dir*='<path>'::
     Specify the directory where *fwknopd* writes run time state files. The
-    default is '@localstatedir@/run'.
+    default is '@localstatedir@'.
 
 *-S, --status*::
     Display the status of any *fwknopd* processes that may or not be
@@ -399,7 +399,7 @@ See the '@sysconfdir@/fwknop/fwknopd.conf' file for the full list and correspond
 
 *FWKNOP_RUN_DIR* '<path>'::
     Specify the directory where *fwknopd* writes run time state files. The
-    default is '@localstatedir@/run'.
+    default is '@localstatedir@'.
 
 ACCESS.CONF VARIABLES
 ~~~~~~~~~~~~~~~~~~~~~

--- a/fwknop.spec
+++ b/fwknop.spec
@@ -8,7 +8,7 @@
 %define _libdir /usr/lib
 %endif
 %define _sysconfdir /etc
-%define _localstatedir /var
+%define _localstatedir /var/run
 %define _infodir /usr/share/info
 %define _mandir /usr/share/man
 

--- a/server/fwknopd.8.in
+++ b/server/fwknopd.8.in
@@ -94,7 +94,7 @@ Specify the location of the
 file\&. If this option is not given,
 \fIfwknopd\fR
 will use the compile\-time default location (typically
-\fI@localstatedir@/run/fwknop/digest\&.cache\fR)\&.
+\fI@localstatedir@/fwknop/digest\&.cache\fR)\&.
 .RE
 .PP
 \fB\-D, \-\-dump\-config\fR
@@ -196,7 +196,7 @@ Specify the location of the
 \fIfwknopd\&.pid\fR
 file\&. If this option is not given,
 \fIfwknopd\fR
-will use the compile\-time default location (typically \*(Aq@localstatedir@/run/fwknop/fwknopd\&.pid)\&.
+will use the compile\-time default location (typically \*(Aq@localstatedir@/fwknop/fwknopd\&.pid)\&.
 .RE
 .PP
 \fB\-P, \-\-pcap\-filter\fR=\fI<filter>\fR
@@ -244,7 +244,7 @@ files\&. This will also force a flush of the current \(lqFWKNOP\(rq iptables cha
 \fB\-\-rotate\-digest\-cache\fR
 .RS 4
 Rotate the digest cache file by renaming it to \(lq<name>\-old\(rq, and starting a new one\&. The digest cache file is typically found in
-\fI@localstatedir@/run/fwknop/digest\&.cache\fR\&.
+\fI@localstatedir@/fwknop/digest\&.cache\fR\&.
 .RE
 .PP
 \fB\-r, \-\-run\-dir\fR=\fI<path>\fR
@@ -252,7 +252,7 @@ Rotate the digest cache file by renaming it to \(lq<name>\-old\(rq, and starting
 Specify the directory where
 \fBfwknopd\fR
 writes run time state files\&. The default is
-\fI@localstatedir@/run\fR\&.
+\fI@localstatedir@\fR\&.
 .RE
 .PP
 \fB\-S, \-\-status\fR
@@ -524,7 +524,7 @@ Override syslog facility\&. The \(lqSYSLOG_FACILITY\(rq variable can be set to
 Specify the directory where
 \fBfwknopd\fR
 writes run time state files\&. The default is
-\fI@localstatedir@/run\fR\&.
+\fI@localstatedir@\fR\&.
 .RE
 .PP
 \fBENABLE_DESTINATION_RULE\fR \fI<Y/N>\fR

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -70,7 +70,7 @@
   /* Our default run directory is based on LOCALSTATEDIR as set by the
    * configure script. This is where we put the PID and digest cache files.
   */
-  #define DEF_RUN_DIR       SYSRUNDIR"/run/"PACKAGE_NAME
+  #define DEF_RUN_DIR       SYSRUNDIR"/"PACKAGE_NAME
 #endif
 
 /* More Conf defaults


### PR DESCRIPTION
Having extra '/run' subdirectory hardcoded into paths used for options
'digest-file', 'pid-file', 'run-dir' is counterintuitive and can lead to
bogus directory layouts when 'localstatedir' differs from the default
value.

For example, if 'localstatedir' is set to '/run', which is a common and
recommended substitute for /var/run in many distros nowadays, then
fwknop files will be placed under /run/run/fwknop.

This changeset removes extra '/run' subdirectory from all relevant paths
by changing DEF_RUN_DIR. Default value of 'localstatedir' is changed to
'/var/run' so users who relied on the previous behaviour won't have to
bother changing anything.

This is tested and works. Gentoo have this patch applied since 2.6.0.