### PR TITLE
extras: adjust 'localstatedir' value for the AppArmor profile

### DIFF
--- a/extras/apparmor/configure_args.sh
+++ b/extras/apparmor/configure_args.sh
@@ -7,7 +7,7 @@
 #
 
 if [ -x ./configure ]; then
-    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var $@
+    ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/run $@
 else
     echo "[*] Execute from the fwknop top level sources directory"
 fi

--- a/extras/apparmor/usr.sbin.fwknopd
+++ b/extras/apparmor/usr.sbin.fwknopd
@@ -1,6 +1,6 @@
 # Last Modified: Sun Aug 18 22:54:57 2013
 # Assumes fwknopd was built with:
-#    './configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var'
+#    './configure --prefix=/usr --sysconfdir=/etc --localstatedir=/run'
 #include <tunables/global>
 
 /usr/sbin/fwknopd {


### PR DESCRIPTION
Comments in the shipped AppArmor profile state that fwknopd is assumed
to be built with 'localstatedir=/var', which is misleading for several
reasons:

* AppArmor profile assumes that fwknopd's pidfile and digest cache are
under /run/fwknop by the looks of it, i.e. 'localstatedir' is '/run'.

* By default these files are placed under /var/run/fwknop. Thus this
profile implicitly relies on the existence of '/var/run -> /run' symlink
and won't work otherwise when 'localstatedir' is '/var'

Since GitHub PR #152 was merged, 'localstatedir' can be simply set to
'/run' for AppArmor users to avoid this confusion. This changeset does
it.

If anyone had it working before, they should have it working now as the
shipped AppArmor profile required /run existence before as well.