### PR TITLE
extras: add systemd unit file and tmpfiles.d configuration for fwknopd

### DIFF
--- a/extras/systemd/fwknopd.service
+++ b/extras/systemd/fwknopd.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Firewall Knock Operator Daemon
+After=network-online.target
+
+[Service]
+Type=forking
+PIDFile=/run/fwknop/fwknopd.pid
+ExecStart=/usr/sbin/fwknopd
+ExecReload=/bin/kill -HUP $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/extras/systemd/fwknopd.tmpfiles.conf
+++ b/extras/systemd/fwknopd.tmpfiles.conf
@@ -1,0 +1,1 @@
+d /run/fwknop 0700 root root -


### PR DESCRIPTION
Hello.

fwknopd daemon is packaged at least for Fedora, Debian and Gentoo. All these distros allow their users to have systemd as the initialization system. Currently, fwknop does not provide any systemd-related configuration.

It would be nice to have a basic, yet working unit file (systemd equivalent for classic initscripts) and tmpfiles.d configuration (a way to tell systemd to fill /run directory with directories in case when /run is tmpfs).

This will ease maintaining for systemd-distros and those who don't use systemd can simply ignore these files since they are small and not getting in the way.