### PR TITLE
X-Forwarded-For HTTP header support

### DIFF
--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -593,6 +593,7 @@ typedef struct spa_data
     char           *spa_message;
     char            spa_message_src_ip[MAX_IPV4_STR_LEN];
     char            pkt_source_ip[MAX_IPV4_STR_LEN];
+    char            pkt_source_xff_ip[MAX_IPV4_STR_LEN];
     char            pkt_destination_ip[MAX_IPV4_STR_LEN];
     char            spa_message_remain[1024]; /* --DSS FIXME: arbitrary bounds */
     char           *nat_access;


### PR DESCRIPTION
The idea here is to support X-Forwarded-For header for HTTP requests proxied from a frontend, for example, when we use '-s' IP-autodetection flag from the client. So when we have some complex multi-tier setup, it would be good to pass client's real IP address in some header.

There could be an option to customize the header name as well. Probably we should think of "trusted" sources too, like it's done for every modern HTTP-server's module (mod_rpaf for Apache, mod_realip for nginx, mod_extforward for LigHTTPD).

This is just the first draft of the solution; thoughts/patches are welcome.