### PR TITLE
Include keys

### DIFF
--- a/server/access.conf
+++ b/server/access.conf
@@ -21,6 +21,24 @@
 #
 ##############################################################################
 #
+### Directives ###
+
+# %include /etc/fwknop/myInlcudeFile.conf
+#
+# This processes the access.conf stanzas from an additional file.
+# Complete stanzas should be contained within each file.
+
+# %include_folder /etc/fwknop/myFolder.d
+#
+# This processes all the *.conf files in the specified directory.
+
+# %include_keys /home/user/fwknop_keys.conf
+#
+# This directive loads the encryption and HMAC keys from an external file.
+# Any other commands in the stanza must come before the %include_keys
+# directive.
+
+### Commands ###
 
 # SOURCE                <IP,..,IP/NET,..,NET/ANY>
 #


### PR DESCRIPTION
This contains logic that allows an access.conf stanza to be ignored if it contains an include_keys directive that doesn't contain valid keys.