### PR TITLE
Hmac hardening

### DIFF
--- a/lib/fko.h
+++ b/lib/fko.h
@@ -1402,6 +1402,7 @@ int register_ts_hmac_test(void);
 int register_ts_digest_test(void);
 int register_ts_aes_test(void);
 int register_utils_test(void);
+int register_base64_test(void);
 #endif
 
 #endif /* FKO_H */

--- a/lib/fko_hmac.c
+++ b/lib/fko_hmac.c
@@ -240,6 +240,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     char *hmac_base64 = NULL;
     int   hmac_digest_str_len = 0;
     int   hmac_digest_len = 0;
+    int   res = FKO_ERROR_UNKNOWN ;
 
     /* Must be initialized
     */
@@ -254,7 +255,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
 
     if(ctx->hmac_type == FKO_HMAC_MD5)
     {
-        hmac_md5(ctx->encrypted_msg,
+        res = hmac_md5(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
 
         hmac_digest_len     = MD5_DIGEST_LEN;
@@ -262,7 +263,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     }
     else if(ctx->hmac_type == FKO_HMAC_SHA1)
     {
-        hmac_sha1(ctx->encrypted_msg,
+        res = hmac_sha1(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
 
         hmac_digest_len     = SHA1_DIGEST_LEN;
@@ -270,7 +271,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     }
     else if(ctx->hmac_type == FKO_HMAC_SHA256)
     {
-        hmac_sha256(ctx->encrypted_msg,
+        res = hmac_sha256(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
 
         hmac_digest_len     = SHA256_DIGEST_LEN;
@@ -278,7 +279,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     }
     else if(ctx->hmac_type == FKO_HMAC_SHA384)
     {
-        hmac_sha384(ctx->encrypted_msg,
+        res = hmac_sha384(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
 
         hmac_digest_len     = SHA384_DIGEST_LEN;
@@ -286,7 +287,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     }
     else if(ctx->hmac_type == FKO_HMAC_SHA512)
     {
-        hmac_sha512(ctx->encrypted_msg,
+        res = hmac_sha512(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
 
         hmac_digest_len     = SHA512_DIGEST_LEN;
@@ -294,7 +295,7 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     }
     else if(ctx->hmac_type == FKO_HMAC_SHA3_256)
     {
-        hmac_sha3_256(ctx->encrypted_msg,
+        res = hmac_sha3_256(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
         hmac_digest_len     = SHA3_256_DIGEST_LEN;
         hmac_digest_str_len = SHA3_256_DIGEST_STR_LEN;
@@ -302,12 +303,15 @@ int fko_set_spa_hmac(fko_ctx_t ctx,
     }
     else if(ctx->hmac_type == FKO_HMAC_SHA3_512)
     {
-        hmac_sha3_512(ctx->encrypted_msg,
+        res = hmac_sha3_512(ctx->encrypted_msg,
             ctx->encrypted_msg_len, hmac, hmac_key, hmac_key_len);
         hmac_digest_len     = SHA3_512_DIGEST_LEN;
         hmac_digest_str_len = SHA3_512_DIGEST_STR_LEN;
 
     }
+
+    if (res != FKO_SUCCESS)
+        return res;
 
     hmac_base64 = calloc(1, MD_HEX_SIZE(hmac_digest_len)+1);
     if (hmac_base64 == NULL)

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -61,7 +61,7 @@ pad_init(unsigned char *inner_pad, unsigned char *outer_pad,
     return;
 }
 
-void
+int
 hmac_md5(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -70,7 +70,10 @@ hmac_md5(const char *msg, const unsigned int msg_len,
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char padded_hash[MD5_BLOCK_LEN + MD5_DIGEST_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
 
     int final_len = hmac_key_len;
 
@@ -86,6 +89,7 @@ hmac_md5(const char *msg, const unsigned int msg_len,
         memcpy(final_key, hmac_key, hmac_key_len);
     }
     pad_init(block_inner_pad, block_outer_pad, final_key, final_len);
+
     //The first step is to hash the inner_pad + message
     memcpy(padded_msg, block_inner_pad, MD5_BLOCK_LEN);
     memcpy(padded_msg + MD5_BLOCK_LEN, msg, msg_len);
@@ -101,10 +105,10 @@ hmac_md5(const char *msg, const unsigned int msg_len,
     md5(hmac, padded_hash, MD5_BLOCK_LEN + MD5_DIGEST_LEN);
 
     free(padded_msg);
-    return;
+    return FKO_SUCCESS;
 }
 
-void
+int
 hmac_sha1(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -113,7 +117,10 @@ hmac_sha1(const char *msg, const unsigned int msg_len,
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char padded_hash[SHA1_BLOCK_LEN + SHA1_DIGEST_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
 
     int final_len = hmac_key_len;
 
@@ -129,6 +136,7 @@ hmac_sha1(const char *msg, const unsigned int msg_len,
         memcpy(final_key, hmac_key, hmac_key_len);
     }
     pad_init(block_inner_pad, block_outer_pad, final_key, final_len);
+
     //The first step is to hash the inner_pad + message
     memcpy(padded_msg, block_inner_pad, SHA1_BLOCK_LEN);
     memcpy(padded_msg + SHA1_BLOCK_LEN, msg, msg_len);
@@ -144,10 +152,10 @@ hmac_sha1(const char *msg, const unsigned int msg_len,
     sha1(hmac, padded_hash, SHA1_BLOCK_LEN + SHA1_DIGEST_LEN);
 
     free(padded_msg);
-    return;
+    return FKO_SUCCESS;
 }
 
-void
+int
 hmac_sha256(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -156,7 +164,10 @@ hmac_sha256(const char *msg, const unsigned int msg_len,
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char padded_hash[SHA256_BLOCK_LEN + SHA256_DIGEST_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
 
     int final_len = hmac_key_len;
 
@@ -172,6 +183,7 @@ hmac_sha256(const char *msg, const unsigned int msg_len,
         memcpy(final_key, hmac_key, hmac_key_len);
     }
     pad_init(block_inner_pad, block_outer_pad, final_key, final_len);
+
     //The first step is to hash the inner_pad + message
     memcpy(padded_msg, block_inner_pad, SHA256_BLOCK_LEN);
     memcpy(padded_msg + SHA256_BLOCK_LEN, msg, msg_len);
@@ -187,10 +199,10 @@ hmac_sha256(const char *msg, const unsigned int msg_len,
     sha256(hmac, padded_hash, SHA256_BLOCK_LEN + SHA256_DIGEST_LEN);
 
     free(padded_msg);
-    return;
+    return FKO_SUCCESS;
 }
 
-void
+int
 hmac_sha384(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -199,7 +211,10 @@ hmac_sha384(const char *msg, const unsigned int msg_len,
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char padded_hash[SHA384_BLOCK_LEN + SHA384_DIGEST_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
 
     int final_len = hmac_key_len;
 
@@ -215,6 +230,7 @@ hmac_sha384(const char *msg, const unsigned int msg_len,
         memcpy(final_key, hmac_key, hmac_key_len);
     }
     pad_init(block_inner_pad, block_outer_pad, final_key, final_len);
+
     //The first step is to hash the inner_pad + message
     memcpy(padded_msg, block_inner_pad, SHA384_BLOCK_LEN);
     memcpy(padded_msg + SHA384_BLOCK_LEN, msg, msg_len);
@@ -230,10 +246,10 @@ hmac_sha384(const char *msg, const unsigned int msg_len,
     sha384(hmac, padded_hash, SHA384_BLOCK_LEN + SHA384_DIGEST_LEN);
 
     free(padded_msg);
-    return;
+    return FKO_SUCCESS;
 }
 
-void
+int
 hmac_sha512(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -242,7 +258,10 @@ hmac_sha512(const char *msg, const unsigned int msg_len,
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char padded_hash[SHA512_BLOCK_LEN + SHA512_DIGEST_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
 
     int final_len = hmac_key_len;
 
@@ -258,6 +277,7 @@ hmac_sha512(const char *msg, const unsigned int msg_len,
         memcpy(final_key, hmac_key, hmac_key_len);
     }
     pad_init(block_inner_pad, block_outer_pad, final_key, final_len);
+
     //The first step is to hash the inner_pad + message
     memcpy(padded_msg, block_inner_pad, SHA512_BLOCK_LEN);
     memcpy(padded_msg + SHA512_BLOCK_LEN, msg, msg_len);
@@ -273,10 +293,10 @@ hmac_sha512(const char *msg, const unsigned int msg_len,
     sha512(hmac, padded_hash, SHA512_BLOCK_LEN + SHA512_DIGEST_LEN);
 
     free(padded_msg);
-    return;
+    return FKO_SUCCESS;
 }
 
-void
+int
 hmac_sha3_256(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -284,8 +304,12 @@ hmac_sha3_256(const char *msg, const unsigned int msg_len,
     unsigned char block_inner_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
-    unsigned char padded_hash[2 * MAX_DIGEST_BLOCK_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char padded_hash[SHA3_256_BLOCK_LEN + SHA3_256_DIGEST_LEN + 1] = {0};
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
+
     int final_len = hmac_key_len;
 
     if(SHA3_256_BLOCK_LEN < hmac_key_len)
@@ -300,6 +324,7 @@ hmac_sha3_256(const char *msg, const unsigned int msg_len,
         memcpy(final_key, hmac_key, hmac_key_len);
     }
     pad_init(block_inner_pad, block_outer_pad, final_key, final_len);
+
     //The first step is to hash the inner_pad + message
     memcpy(padded_msg, block_inner_pad, SHA3_256_BLOCK_LEN);
     memcpy(padded_msg + SHA3_256_BLOCK_LEN, msg, msg_len);
@@ -315,9 +340,10 @@ hmac_sha3_256(const char *msg, const unsigned int msg_len,
     FIPS202_SHA3_256(padded_hash, SHA3_256_BLOCK_LEN + SHA3_256_DIGEST_LEN, hmac);
 
     free(padded_msg);
+    return FKO_SUCCESS;
 }
 
-void
+int
 hmac_sha3_512(const char *msg, const unsigned int msg_len,
     unsigned char *hmac, const char *hmac_key, const int hmac_key_len)
 {
@@ -326,7 +352,10 @@ hmac_sha3_512(const char *msg, const unsigned int msg_len,
     unsigned char block_outer_pad[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char final_key[MAX_DIGEST_BLOCK_LEN] = {0};
     unsigned char padded_hash[SHA3_512_BLOCK_LEN + SHA3_512_DIGEST_LEN + 1] = {0};
-    unsigned char *padded_msg = malloc(msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+    unsigned char *padded_msg = calloc(1, msg_len + MAX_DIGEST_BLOCK_LEN + 1);
+
+    if (padded_msg == NULL)
+        return FKO_ERROR_MEMORY_ALLOCATION;
 
     int final_len = hmac_key_len;
 
@@ -358,6 +387,7 @@ hmac_sha3_512(const char *msg, const unsigned int msg_len,
     FIPS202_SHA3_512(padded_hash, SHA3_512_BLOCK_LEN + SHA3_512_DIGEST_LEN, hmac);
 
     free(padded_msg);
+    return FKO_SUCCESS;
 }
 
 #ifdef HAVE_C_UNIT_TESTS

--- a/lib/hmac.h
+++ b/lib/hmac.h
@@ -44,8 +44,9 @@
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_md5(const char *msg, const unsigned int msg_len,
+int hmac_md5(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 /**
  * \brief Generate SHA1 based HMAC
@@ -58,8 +59,9 @@ void hmac_md5(const char *msg, const unsigned int msg_len,
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_sha1(const char *msg, const unsigned int msg_len,
+int hmac_sha1(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 /**
  * \brief Generate SHA256 based HMAC
@@ -72,8 +74,9 @@ void hmac_sha1(const char *msg, const unsigned int msg_len,
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_sha256(const char *msg, const unsigned int msg_len,
+int hmac_sha256(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 /**
  * \brief Generate SHA384 based HMAC
@@ -86,8 +89,9 @@ void hmac_sha256(const char *msg, const unsigned int msg_len,
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_sha384(const char *msg, const unsigned int msg_len,
+int hmac_sha384(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 /**
  * \brief Generate SHA512 based HMAC
@@ -100,8 +104,9 @@ void hmac_sha384(const char *msg, const unsigned int msg_len,
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_sha512(const char *msg, const unsigned int msg_len,
+int hmac_sha512(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 /**
  * \brief Generate SHA3-256 based HMAC
@@ -114,8 +119,9 @@ void hmac_sha512(const char *msg, const unsigned int msg_len,
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_sha3_256(const char *msg, const unsigned int msg_len,
+int hmac_sha3_256(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 /**
  * \brief Generate SHA3-512 based HMAC
@@ -128,8 +134,9 @@ void hmac_sha3_256(const char *msg, const unsigned int msg_len,
  * \param hmac_key Pointer to the key to be used for generating the hmac
  * \param hmac_key_len Size of the hmac key
  *
+ * \return FKO_SUCCESS if successful, returns an error code otherwise.
  */
-void hmac_sha3_512(const char *msg, const unsigned int msg_len,
+int hmac_sha3_512(const char *msg, const unsigned int msg_len,
         unsigned char *hmac, const char *hmac_key, const int hmac_key_len);
 
 #endif /* HMAC_H */


### PR DESCRIPTION
Adds a missed CUnit declaration in the first commit.  Second commit implements hardening/null checks as discussed in previous pull.