### PR TITLE
Fix Ubuntu AppArmor regression

### DIFF
--- a/extras/apparmor/usr.sbin.fwknopd
+++ b/extras/apparmor/usr.sbin.fwknopd
@@ -12,6 +12,7 @@
 
   network inet raw,
   network packet raw,
+  network packet dgram,
 
   /bin/dash rix,
   /bin/bash rix,


### PR DESCRIPTION
Error: 
$ sudo fwknopd -f -c /etc/fwknop/fwknopd.conf 
Starting fwknopd
Added jump rule from chain: INPUT to chain: FWKNOP_INPUT
iptables 'comment' match is available
Sniffing interface: ppp0
[*] pcap_open_live() error: ppp0: You don't have permission to capture on that device (socket: Permission denied)

Syslog:

[...] kernel: [...] type=1400 audit([...]): apparmor="DENIED" operation="create" profile="/usr/sbin/fwknopd" pid=[...] comm="fwknopd" family="packet" sock_type="dgram" protocol=768