### PR TITLE
Fix client/Makefile.am to work with libtool 2.4.6 from Cygwin

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -20,7 +20,7 @@ endif
 
 fwknop_CPPFLAGS     = -I $(top_srcdir)/lib -I $(top_srcdir)/common
 
-fwknop_LDADD        = $(top_builddir)/lib/libfko.la $(top_builddir)/common/libfko_util.a
+fwknop_LDADD        = -L$(top_builddir)/common -lfko_util $(top_builddir)/lib/libfko.la
 
 dist_man_MANS       = fwknop.8
 


### PR DESCRIPTION
When trying to build on my up to date Cygwin installation, I got the following error:

```
/bin/sh ../libtool  --tag=CC   --mode=link gcc  -g -O2 -Wall -Wformat -Wformat-security -fstack-protector-all -fstack-protector -D_FORTIFY_SOURCE=2  -Wall -Wformat -Wformat-security -fstack-protector-all -fstack-protector -D_FORTIFY_SOURCE=2 -o fwknop.exe fwknop-fwknop.o fwknop-config_init.o fwknop-spa_comm.o fwknop-utils.o fwknop-http_resolve_host.o fwknop-getpasswd.o fwknop-log_msg.o ../lib/libfko.la ../common/libfko_util.a
libtool: link: gcc -g -O2 -Wall -Wformat -Wformat-security -fstack-protector-all -fstack-protector -D_FORTIFY_SOURCE=2 -Wall -Wformat -Wformat-security -fstack-protector-all -fstack-protector -D_FORTIFY_SOURCE=2 -o .libs/fwknop.exe fwknop-fwknop.o fwknop-config_init.o fwknop-spa_comm.o fwknop-utils.o fwknop-http_resolve_host.o fwknop-getpasswd.o fwknop-log_msg.o  ../lib/.libs/libfko.a ../common/libfko_util.a
../common/libfko_util.a(fko_util.o): In function `dump_ctx_to_buffer':
/home/Benjamin/Documents/src/com.github/mrash/fwknop/common/fko_util.c:876: undefined reference to `fko_get_spa_server_auth'
/home/Benjamin/Documents/src/com.github/mrash/fwknop/common/fko_util.c:876:(.text+0xf1b): relocation truncated to fit: R_X86_64_PC32 against undefined symbol `fko_get_spa_server_auth'
collect2: error: ld returned 1 exit status
Makefile:459: recipe for target 'fwknop.exe' failed
make[2]: *** [fwknop.exe] Error 1
make[2]: Leaving directory '/home/Benjamin/Documents/src/com.github/mrash/fwknop/client'
Makefile:885: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/home/Benjamin/Documents/src/com.github/mrash/fwknop'
Makefile:816: recipe for target 'all' failed
make: *** [all] Error 2
```

The provided patch seems to fix the issue here.