### PR TITLE
Needs review -- refactors the client's nat validation

### DIFF
--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -785,8 +785,12 @@ set_nat_access(fko_ctx_t ctx, fko_cli_options_t *options, const char * const acc
 
             ndx++;
             i = 0;
-            while(*ndx != '\0' && isdigit(*ndx) && i < MAX_PORT_STR_LEN)
+            while(*ndx != '\0')
             {
+                if ((!isdigit(*ndx)) || (i >= MAX_PORT_STR_LEN)) {
+                    log_msg(LOG_VERBOSITY_ERROR, "[*] Invalid port value in -N arg.");
+                    return FKO_ERROR_INVALID_DATA;
+                }
                 tmp_nat_port[i] = *ndx;
                 ndx++;
                 i++;

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -59,7 +59,6 @@ static void clean_exit(fko_ctx_t ctx, fko_cli_options_t *opts,
     char *key, int *key_len, char *hmac_key, int *hmac_key_len,
     unsigned int exit_status);
 static void zero_buf_wrapper(char *buf, int len);
-static int is_hostname_str_with_port(const char *str);
 #if HAVE_LIBFIU
 static int enable_fault_injections(fko_cli_options_t * const opts);
 #endif
@@ -75,71 +74,6 @@ static int enable_fault_injections(fko_cli_options_t * const opts);
 #define NAT_ACCESS_STR_TEMPLATE     "%s,%d"             /*!< Template for a nat access string ip,port with sscanf*/
 #define HOSTNAME_BUFSIZE            64                  /*!< Maximum size of a hostname string */
 #define CTX_DUMP_BUFSIZE            4096                /*!< Maximum size allocated to a FKO context dump */
-
-/**
- * @brief Check whether a string is an ipv6 address or not
- *
- * @param str String to check for an ipv6 address.
- *
- * @return 1 if the string is an ipv6 address, 0 otherwise.
- */
-static int
-is_ipv6_str(char *str)
-{
-    return 0;
-}
-
-/**
- * @brief Check a string to find out if it is built as 'hostname,port'
- *
- * This function checks if there is a hostname and a port in the string.
- *
- * We could have used sscanf() here with a template "%[^,],%u", but this way we
- * do not limit the size of the value copy in the hostname destination buffer.
- * Limiting the string in the sscanf() can be done but would prevent any easy change
- * for the hostname buffer size.
- *
- * @param str String to parse.
- *
- * @return 1 if the string is built as 'hostname,port', 0 otherwise.
- */
-static int
-is_hostname_str_with_port(const char *str)
-{
-    int     valid = 0;                /* Result of the function */
-    int     port = 0;                 /* temporary int to store port */
-    char    buf[MAX_LINE_LEN] = {0};  /* Copy of the buffer eg. "hostname,port" */
-    char   *p;                        /* Ponter on the port string */
-
-
-    /* Replace the comma in the string with a NULL char to split the
-     * buffer in two strings (hostname and port) */
-    strlcpy(buf, str, sizeof(buf));
-    p = strchr(buf, ',');
-
-    if(p != NULL)
-    {
-        *p++ = 0;
-        port = atoi(p);
-
-        /* If the string does not match an ipv4 or ipv6 address we assume this
-         * is an hostname. We make sure the port is in the good range too */
-        if (   (is_valid_ipv4_addr(buf) == 0)
-            && (is_ipv6_str(buf) == 0)
-            && ((port > 0) && (port < 65536)) )
-        {
-            valid = 1;
-        }
-
-        /* The port is out of range or the ip is an ipv6 or ipv4 address */
-        else;
-    }
-
-    /* No port found in the string, let's skip */
-    else;
-
-    return valid;
-}
 
 int
 main(int argc, char **argv)
@@ -722,34 +656,6 @@ get_rand_port(fko_ctx_t ctx)
     return port;
 }
 
-/* See if the string is of the format "<ipv4 addr>:<port>",
- */
-static int
-ipv4_str_has_port(char *str)
-{
-    int o1, o2, o3, o4, p;
-
-    /* Force the ':' (if any) to a ','
-    */
-    char *ndx = strchr(str, ':');
-    if(ndx != NULL)
-        *ndx = ',';
-
-    /* Check format and values.
-    */
-    if((sscanf(str, "%u.%u.%u.%u,%u", &o1, &o2, &o3, &o4, &p)) == 5
-        && o1 >= 0 && o1 <= 255
-        && o2 >= 0 && o2 <= 255
-        && o3 >= 0 && o3 <= 255
-        && o4 >= 0 && o4 <= 255
-        && p  >  0 && p  <  65536)
-    {
-        return 1;
-    }
-
-    return 0;
-}
-
 /* Set access buf
 */
 static int
@@ -826,6 +732,7 @@ static int
 set_nat_access(fko_ctx_t ctx, fko_cli_options_t *options, const char * const access_buf)
 {
     char                nat_access_buf[MAX_LINE_LEN] = {0};
+    char                tmp_nat_port[MAX_LINE_LEN] = {0};
     char                tmp_access_port[MAX_PORT_STR_LEN+1] = {0}, *ndx = NULL;
     int                 access_port = 0, i = 0, is_err = 0;
     struct addrinfo     hints;
@@ -865,15 +772,52 @@ set_nat_access(fko_ctx_t ctx, fko_cli_options_t *options, const char * const acc
 
     if (nat_access_buf[0] == 0x0 && options->nat_access_str[0] != 0x0)
     {
-        if (ipv4_str_has_port(options->nat_access_str) || is_hostname_str_with_port(options->nat_access_str))
+        /* Force the ':' (if any) to a ','
+        */
+        ndx = strchr(options->nat_access_str, ':');
+        if (ndx != NULL)
+            *ndx = ',';
+
+        ndx = strchr(options->nat_access_str, ',');
+        if (ndx != NULL)
         {
-            snprintf(nat_access_buf, MAX_LINE_LEN, "%s",
-                options->nat_access_str);
+            *ndx = 0;
+
+            ndx++;
+            i = 0;
+            while(*ndx != '\0' && isdigit(*ndx) && i < MAX_PORT_STR_LEN)
+            {
+                tmp_nat_port[i] = *ndx;
+                ndx++;
+                i++;
+            }
+            tmp_nat_port[i] = '\0';
+            access_port = strtol_wrapper(tmp_nat_port, 1,
+                        MAX_PORT, NO_EXIT_UPON_ERR, &is_err);
+            if (is_err != FKO_SUCCESS)
+            {
+                log_msg(LOG_VERBOSITY_ERROR, "[*] Invalid port value in -N arg.");
+                return FKO_ERROR_INVALID_DATA;
+            }
         }
-        else
+
+        if ((access_port < 1) | (access_port > 65535))
+        {
+            log_msg(LOG_VERBOSITY_ERROR, "[*] Invalid port value.");
+            return FKO_ERROR_INVALID_DATA;
+        }
+
+
+        if (is_valid_ipv4_addr(options->nat_access_str) || is_valid_hostname(options->nat_access_str))
         {
             snprintf(nat_access_buf, MAX_LINE_LEN, NAT_ACCESS_STR_TEMPLATE,
                 options->nat_access_str, access_port);
+        }
+        else
+        {
+            log_msg(LOG_VERBOSITY_ERROR, "[*] Invalid NAT destination '%s' for -N arg.",
+                options->nat_access_str);
+            return FKO_ERROR_INVALID_DATA;
         }
     }
 

--- a/common/fko_util.c
+++ b/common/fko_util.c
@@ -171,6 +171,68 @@ is_valid_ipv4_addr(const char * const ip_str)
     return(res);
 }
 
+/* Validate a hostname
+*/
+int
+is_valid_hostname(const char * const hostname_str)
+{
+    int                 label_size = 0, total_size = 0;
+    const char         *ndx     = hostname_str;
+
+    if (hostname_str == NULL)
+        return 0;
+
+    while(*ndx != '\0')
+    {
+        if (label_size == 0) //More restrictions on first character of a label
+        {
+            if (!isalnum(*ndx))
+                return 0;
+        }
+        else if (!(isalnum(*ndx) | (*ndx == '.') | (*ndx == '-')))
+            return 0;
+
+        if (*ndx == '.')
+        {
+            if (label_size > 63)
+                return 0;
+            if (!isalnum(*(ndx-1)))  //checks that previous character was not a . or -
+                return 0;
+
+            label_size = 0;
+        }
+        else
+        {
+            label_size++;
+        }
+
+        total_size++;
+
+        if (total_size > 254)
+            return 0;
+
+        ndx++; //move to next character
+    }
+    /* At this point, we're pointing at the null.  Decrement ndx for simplicity
+    */
+    ndx--;
+    if (*ndx == '-')
+        return 0;
+
+    if (*ndx == '.')
+        total_size--;
+
+    if (total_size > 253)
+        return 0;
+
+    if (label_size > 63)
+        return 0;
+
+    /* By now we've bailed if invalid
+    */
+    return 1;
+}
+
 /* Convert a digest_type string to its integer value.
 */
 short

--- a/common/fko_util.c
+++ b/common/fko_util.c
@@ -1149,6 +1149,28 @@ count_characters(const char *str, const char match, int len)
 
 #ifdef HAVE_C_UNIT_TESTS
 
+DECLARE_UTEST(test_hostname_validator, "test the is_valid_hostname function")
+{
+    char test_hostname[300];
+    strcpy(test_hostname, "a");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 1);
+    strcpy(test_hostname, "a.b");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 1);
+    strcpy(test_hostname, "a.b.");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 1);
+    strcpy(test_hostname, "a.");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 1);
+
+    strcpy(test_hostname, "a..b");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 0);
+    strcpy(test_hostname, ".a.b");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 0);
+    strcpy(test_hostname, "a-.b");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 0);
+    strcpy(test_hostname, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.b");
+    CU_ASSERT(is_valid_hostname(test_hostname) == 0);
+}
+
 DECLARE_UTEST(test_count_characters, "test the count_characters function")
 {
     char test_str[32];
@@ -1168,6 +1190,7 @@ int register_utils_test(void)
 {
     ts_init(&TEST_SUITE(utils_test), TEST_SUITE_DESCR(utils_test), NULL, NULL);
     ts_add_utest(&TEST_SUITE(utils_test), UTEST_FCT(test_count_characters), UTEST_DESCR(test_count_characters));
+    ts_add_utest(&TEST_SUITE(utils_test), UTEST_FCT(test_hostname_validator), UTEST_DESCR(test_hostname_validator));
 
     return register_ts(&TEST_SUITE(utils_test));
 }

--- a/common/fko_util.h
+++ b/common/fko_util.h
@@ -41,6 +41,7 @@
 int     is_valid_encoded_msg_len(const int len);
 int     is_valid_pt_msg_len(const int len);
 int     is_valid_ipv4_addr(const char * const ip_str);
+int     is_valid_hostname(const char * const hostname_str);
 int     is_base64(const unsigned char * const buf, const unsigned short int len);
 void    hex_dump(const unsigned char *data, const int size);
 int     enc_mode_strtoint(const char *enc_mode_str);

--- a/server/fw_util_firewalld.c
+++ b/server/fw_util_firewalld.c
@@ -1549,10 +1549,15 @@ process_spa_request(const fko_srv_options_t * const opts,
             if((ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN))
             {
                 strlcpy(nat_dst, spadat->nat_access, str_len+1);
-                if((! is_valid_ipv4_addr(nat_dst)))
+                if (! is_valid_ipv4_addr(nat_dst))
                 {
-                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1)==0)
+                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1) == 0)
                     {
+                        if (!is_valid_hostname(nat_dst))
+                        {
+                            log_msg(LOG_INFO, "Invalid Hostname in NAT SPA message");
+                            return res;
+                        }
                         if (ipv4_resolve(nat_dst, nat_ip) == 0)
                         {
                             log_msg(LOG_INFO, "Resolved NAT IP in SPA message");
@@ -1561,7 +1566,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                         {
                             log_msg(LOG_INFO, "Unable to resolve Hostname in NAT SPA message");
                             free_acc_port_list(port_list);
-                            res = is_err;
                             return res;
                         }
                     }
@@ -1569,7 +1573,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                     {
                         log_msg(LOG_INFO, "Received Hostname in NAT SPA message, but hostname is disabled.");
                         free_acc_port_list(port_list);
-                        res = is_err;
                         return res;
 
                     }
@@ -1593,7 +1596,6 @@ process_spa_request(const fko_srv_options_t * const opts,
             {
                 log_msg(LOG_INFO, "Invalid NAT IP in SPA message");
                 free_acc_port_list(port_list);
-                res = is_err;
                 return res;
             }
         }

--- a/server/fw_util_iptables.c
+++ b/server/fw_util_iptables.c
@@ -1538,10 +1538,15 @@ process_spa_request(const fko_srv_options_t * const opts,
             if((ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN))
             {
                 strlcpy(nat_dst, spadat->nat_access, str_len+1);
-                if((! is_valid_ipv4_addr(nat_dst)))
+                if (! is_valid_ipv4_addr(nat_dst))
                 {
-                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1)==0)
+                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1) == 0)
                     {
+                        if (!is_valid_hostname(nat_dst))
+                        {
+                            log_msg(LOG_INFO, "Invalid Hostname in NAT SPA message");
+                            return res;
+                        }
                         if (ipv4_resolve(nat_dst, nat_ip) == 0)
                         {
                             log_msg(LOG_INFO, "Resolved NAT IP in SPA message");
@@ -1550,7 +1555,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                         {
                             log_msg(LOG_INFO, "Unable to resolve Hostname in NAT SPA message");
                             free_acc_port_list(port_list);
-                            res = is_err;
                             return res;
                         }
                     }
@@ -1558,7 +1562,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                     {
                         log_msg(LOG_INFO, "Received Hostname in NAT SPA message, but hostname is disabled.");
                         free_acc_port_list(port_list);
-                        res = is_err;
                         return res;
 
                     }
@@ -1582,7 +1585,6 @@ process_spa_request(const fko_srv_options_t * const opts,
             {
                 log_msg(LOG_INFO, "Invalid NAT IP in SPA message");
                 free_acc_port_list(port_list);
-                res = is_err;
                 return res;
             }
         }

--- a/test/tests/basic_operations.pl
+++ b/test/tests/basic_operations.pl
@@ -1676,7 +1676,7 @@
                 'vars' => {'KEY' => 'testtest', 'HMAC_KEY' => 'hmactest',
                     'HMAC_DIGEST_TYPE' => 'SHA1', 'NAT_PORT' => '11111'}}],
         'exec_err' => $YES,
-        'positive_output_matches' => [qr/Unable\sto\sresolve/]
+        'positive_output_matches' => [qr/Invalid\sNAT\sdestination/]
     },
     {
         'category' => 'basic operations',

--- a/test/tests/rijndael.pl
+++ b/test/tests/rijndael.pl
@@ -881,7 +881,7 @@
         'detail'   => "NAT bogus IP validation",
         'function' => \&generic_exec,
         'exec_err' => $YES,
-        'cmdline'  => "$default_client_args -N 999.1.1.1:22",
+        'cmdline'  => "$default_client_args -N 192>.168.100.100:22",
     },
 
     {

--- a/test/tests/rijndael_hmac.pl
+++ b/test/tests/rijndael_hmac.pl
@@ -1742,7 +1742,7 @@
         'function' => \&generic_exec,
         'exec_err' => $YES,
         'cmdline'  => "$default_client_args_no_get_key --rc-file " .
-            "$cf{'rc_hmac_b64_key'} -N 999.1.1.1:22",
+            "$cf{'rc_hmac_b64_key'} -N 192,1.1.1:22",
         'key_file' => $cf{'rc_hmac_b64_key'},
     },
     {


### PR DESCRIPTION
This adds is_valid_hostname() to common/fko_util, and then uses that function in both the server and the client to validate nat strings.

Updates a failing test with the new error message, resulting in a passing test.

Adds a basic c-unit test for is_valid_hostname().

Removes the "NAT bogus IP validation" test, as the bogus IP tested is technically a valid hostname.