### PR TITLE
Add nat validation

### DIFF
--- a/server/fw_util_firewalld.c
+++ b/server/fw_util_firewalld.c
@@ -1549,9 +1549,9 @@ process_spa_request(const fko_srv_options_t * const opts,
             if((ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN))
             {
                 strlcpy(nat_dst, spadat->nat_access, str_len+1);
-                if((! is_valid_ipv4_addr(nat_dst, strlen(nat_dst))))
+                if(! is_valid_ipv4_addr(nat_dst, strlen(nat_dst)))
                 {
-                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1)==0)
+                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1) == 0)
                     {
                         if (ipv4_resolve(nat_dst, nat_ip) == 0)
                         {
@@ -1561,7 +1561,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                         {
                             log_msg(LOG_INFO, "Unable to resolve Hostname in NAT SPA message");
                             free_acc_port_list(port_list);
-                            res = is_err;
                             return res;
                         }
                     }
@@ -1569,7 +1568,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                     {
                         log_msg(LOG_INFO, "Received Hostname in NAT SPA message, but hostname is disabled.");
                         free_acc_port_list(port_list);
-                        res = is_err;
                         return res;
 
                     }
@@ -1593,7 +1591,6 @@ process_spa_request(const fko_srv_options_t * const opts,
             {
                 log_msg(LOG_INFO, "Invalid NAT IP in SPA message");
                 free_acc_port_list(port_list);
-                res = is_err;
                 return res;
             }
         }

--- a/server/fw_util_firewalld.c
+++ b/server/fw_util_firewalld.c
@@ -1549,10 +1549,15 @@ process_spa_request(const fko_srv_options_t * const opts,
             if((ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN))
             {
                 strlcpy(nat_dst, spadat->nat_access, str_len+1);
-                if(! is_valid_ipv4_addr(nat_dst, strlen(nat_dst)))
+                if(! is_valid_ipv4_addr(nat_dst, str_len))
                 {
                     if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1) == 0)
                     {
+                        if (!is_valid_hostname(nat_dst, str_len))
+                        {
+                            log_msg(LOG_INFO, "Invalid Hostname in NAT SPA message");
+                            return res;
+                        }
                         if (ipv4_resolve(nat_dst, nat_ip) == 0)
                         {
                             log_msg(LOG_INFO, "Resolved NAT IP in SPA message");

--- a/server/fw_util_iptables.c
+++ b/server/fw_util_iptables.c
@@ -1538,10 +1538,15 @@ process_spa_request(const fko_srv_options_t * const opts,
             if(ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN)
             {
                 strlcpy(nat_dst, spadat->nat_access, str_len+1);
-                if(! is_valid_ipv4_addr(nat_dst, strlen(nat_dst)))
+                if(! is_valid_ipv4_addr(nat_dst, str_len))
                 {
                     if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1) == 0)
                     {
+                        if (!is_valid_hostname(nat_dst, str_len))
+                        {
+                            log_msg(LOG_INFO, "Invalid Hostname in NAT SPA message");
+                            return res;
+                        }
                         if (ipv4_resolve(nat_dst, nat_ip) == 0)
                         {
                             log_msg(LOG_INFO, "Resolved NAT IP in SPA message");

--- a/server/fw_util_iptables.c
+++ b/server/fw_util_iptables.c
@@ -1535,12 +1535,12 @@ process_spa_request(const fko_srv_options_t * const opts,
         {
             ndx = strchr(spadat->nat_access, ',');
             str_len = strcspn(spadat->nat_access, ",");
-            if((ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN))
+            if(ndx != NULL) && (str_len <= MAX_HOSTNAME_LEN)
             {
                 strlcpy(nat_dst, spadat->nat_access, str_len+1);
                 if(! is_valid_ipv4_addr(nat_dst, strlen(nat_dst)))
                 {
-                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1)==0)
+                    if(strncasecmp(opts->config[CONF_ENABLE_NAT_DNS], "Y", 1) == 0)
                     {
                         if (ipv4_resolve(nat_dst, nat_ip) == 0)
                         {
@@ -1550,7 +1550,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                         {
                             log_msg(LOG_INFO, "Unable to resolve Hostname in NAT SPA message");
                             free_acc_port_list(port_list);
-                            res = is_err;
                             return res;
                         }
                     }
@@ -1558,7 +1557,6 @@ process_spa_request(const fko_srv_options_t * const opts,
                     {
                         log_msg(LOG_INFO, "Received Hostname in NAT SPA message, but hostname is disabled.");
                         free_acc_port_list(port_list);
-                        res = is_err;
                         return res;
 
                     }
@@ -1582,7 +1580,6 @@ process_spa_request(const fko_srv_options_t * const opts,
             {
                 log_msg(LOG_INFO, "Invalid NAT IP in SPA message");
                 free_acc_port_list(port_list);
-                res = is_err;
                 return res;
             }
         }


### PR DESCRIPTION
Fairly straightforward; I think it bulletproofs the nat-dns feature quite a bit.  Allowing non-valid hostnames could be quite problematic, especially since those are part of strings that get executed as root.
edit: remove derp