### PR TITLE
[Server] slightly broadens FORWARD rule matching, disables rewriting …

### DIFF
--- a/server/fw_util_firewalld.c
+++ b/server/fw_util_firewalld.c
@@ -1279,9 +1279,9 @@ static void forward_access_rule(const fko_srv_options_t * const opts,
             "forward_access_rule() forward_all: %d, nat_ip: %s, nat_port: %d",
             acc->forward_all, nat_ip, nat_port);
 
+    memset(rule_buf, 0, CMD_BUFSIZE);
     if(acc->forward_all)
     {
-        memset(rule_buf, 0, CMD_BUFSIZE);
 
         snprintf(rule_buf, CMD_BUFSIZE-1, FIREWD_FWD_ALL_RULE_ARGS,
             fwd_chain->table,
@@ -1300,8 +1300,16 @@ static void forward_access_rule(const fko_srv_options_t * const opts,
     {
         /* Make the FORWARD access rule
         */
-        firewd_rule(opts, NULL, FIREWD_FWD_RULE_ARGS, spadat->use_src_ip,
-            nat_ip, fst_proto, nat_port, NULL, NAT_ANY_PORT,
+        snprintf(rule_buf, CMD_BUFSIZE-1, FIREWD_FWD_RULE_ARGS,
+            fwd_chain->table,
+            fst_proto,
+            spadat->use_src_ip,
+            nat_port,
+            exp_ts,
+            fwd_chain->target
+        );
+        firewd_rule(opts, rule_buf, NULL, spadat->use_src_ip,
+            NULL, fst_proto, nat_port, NULL, NAT_ANY_PORT,
             fwd_chain, exp_ts, now, "FORWARD", spadat->spa_message_remain);
     }
     return;
@@ -1433,7 +1441,7 @@ static void snat_rule(const fko_srv_options_t * const opts,
             /* Using static SNAT */
             snat_chain = &(opts->fw_config->chain[FIREWD_SNAT_ACCESS]);
             snprintf(snat_target, SNAT_TARGET_BUFSIZE-1,
-                "--to-source %s:%i", acc->force_snat_ip, fst_port);
+                "--to-source %s", acc->force_snat_ip);
         }
         else if(acc->force_snat && acc->force_masquerade)
         {
@@ -1448,8 +1456,7 @@ static void snat_rule(const fko_srv_options_t * const opts,
             /* Using static SNAT */
             snat_chain = &(opts->fw_config->chain[FIREWD_SNAT_ACCESS]);
             snprintf(snat_target, SNAT_TARGET_BUFSIZE-1,
-                "--to-source %s:%i", opts->config[CONF_SNAT_TRANSLATE_IP],
-                fst_port);
+                "--to-source %s", opts->config[CONF_SNAT_TRANSLATE_IP]);
         }
         else
         {

--- a/server/fw_util_firewalld.h
+++ b/server/fw_util_firewalld.h
@@ -46,7 +46,7 @@
 #define FIREWD_CHK_RULE_ARGS       "-C %s %s" /* the other macros add SH_REDIR if necessary */
 #define FIREWD_RULE_ARGS           "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
 #define FIREWD_OUT_RULE_ARGS       "-t %s -p %i -d %s -s %s --sport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
-#define FIREWD_FWD_RULE_ARGS       "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
+#define FIREWD_FWD_RULE_ARGS       "-t %s -p %i -s %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
 #define FIREWD_FWD_ALL_RULE_ARGS   "-t %s -s %s -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
 #define FIREWD_DNAT_RULE_ARGS      "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s --to-destination %s:%i" SH_REDIR
 #define FIREWD_DNAT_ALL_RULE_ARGS  "-t %s -s %s -d %s -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s --to-destination %s" SH_REDIR

--- a/server/fw_util_iptables.h
+++ b/server/fw_util_iptables.h
@@ -43,7 +43,7 @@
 #define IPT_CHK_RULE_ARGS       "-C %s %s" /* the other macros add SH_REDIR if necessary */
 #define IPT_RULE_ARGS           "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
 #define IPT_OUT_RULE_ARGS       "-t %s -p %i -d %s -s %s --sport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
-#define IPT_FWD_RULE_ARGS       "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
+#define IPT_FWD_RULE_ARGS       "-t %s -p %i -s %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
 #define IPT_FWD_ALL_RULE_ARGS   "-t %s -s %s -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s" SH_REDIR
 #define IPT_DNAT_RULE_ARGS      "-t %s -p %i -s %s -d %s --dport %i -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s --to-destination %s:%i" SH_REDIR
 #define IPT_DNAT_ALL_RULE_ARGS  "-t %s -s %s -d %s -m comment --comment " EXPIRE_COMMENT_PREFIX "%u -j %s --to-destination %s" SH_REDIR


### PR DESCRIPTION
…sport for snat

I was unsuccessful at using fwknopd to do snat/snat when fwknopd was not the gateway for the final target machine.  There were two issues.  The forward rule was too narrow and not matching, and the snat rule was rewriting the source port.