### PR TITLE
fix spelling errors flagged by Debian lintian

### DIFF
--- a/doc/libfko.texi
+++ b/doc/libfko.texi
@@ -425,7 +425,7 @@ for this type is: @samp{<ip of requestor>,<command text>}.
 @item FKO_ACCESS_MSG
 A basic access request.  This is the most common type in use. The format
 for this type is: @samp{<ip of requestor>,<protocol>/<port>}.  Note that
-mulitple protocol/port entries are allowed.
+multiple protocol/port entries are allowed.
 @example
 "192.168.1.2,tcp/22"
 "192.168.1.2,tcp/22,udp/5005"
@@ -1548,7 +1548,7 @@ Error from signer keylist start operation
 @item FKO_ERROR_GPGME_SIGNER_KEY_NOT_FOUND
 The key for the given signer was not found
 @item FKO_ERROR_GPGME_SIGNER_KEY_AMBIGUOUS
-Ambiguous name/id for the signer key (mulitple matches)
+Ambiguous name/id for the signer key (multiple matches)
 @item FKO_ERROR_GPGME_ADD_SIGNER
 Error adding the signer key to the gpgme context
 @item FKO_ERROR_GPGME_CONTEXT_RECIPIENT_KEY
@@ -1558,7 +1558,7 @@ Error from signer keylist start operation
 @item FKO_ERROR_GPGME_RECIPIENT_KEY_NOT_FOUND
 The key for the given recipient was not found
 @item FKO_ERROR_GPGME_RECIPIENT_KEY_AMBIGUOUS
-Ambiguous name/id for the recipient key (mulitple matches)
+Ambiguous name/id for the recipient key (multiple matches)
 @item FKO_ERROR_GPGME_DECRYPT_FAILED
 Decryption operation failed
 @item FKO_ERROR_GPGME_BAD_GPG_EXE

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -288,12 +288,12 @@ typedef enum {
     FKO_ERROR_GPGME_CONTEXT_SIGNER_KEY, /**< Unable to create GPGME context for the signer key*/
     FKO_ERROR_GPGME_SIGNER_KEYLIST_START, /**< Error from signer keylist start operation*/
     FKO_ERROR_GPGME_SIGNER_KEY_NOT_FOUND, /**< The key for the given signer was not found*/
-    FKO_ERROR_GPGME_SIGNER_KEY_AMBIGUOUS, /**< Ambiguous name/id for the signer key (mulitple matches)*/
+    FKO_ERROR_GPGME_SIGNER_KEY_AMBIGUOUS, /**< Ambiguous name/id for the signer key (multiple matches)*/
     FKO_ERROR_GPGME_ADD_SIGNER, /**< Error adding the signer key to the gpgme context*/
     FKO_ERROR_GPGME_CONTEXT_RECIPIENT_KEY, /**< Unable to create GPGME context for the recipient key*/
     FKO_ERROR_GPGME_RECIPIENT_KEYLIST_START, /**< Error from signer keylist start operation*/
     FKO_ERROR_GPGME_RECIPIENT_KEY_NOT_FOUND, /**< The key for the given recipient was not found*/
-    FKO_ERROR_GPGME_RECIPIENT_KEY_AMBIGUOUS, /**< Ambiguous name/id for the recipient key (mulitple matches)*/
+    FKO_ERROR_GPGME_RECIPIENT_KEY_AMBIGUOUS, /**< Ambiguous name/id for the recipient key (multiple matches)*/
     FKO_ERROR_GPGME_DECRYPT_FAILED, /**< Decryption operation failed*/
     FKO_ERROR_GPGME_DECRYPT_UNSUPPORTED_ALGORITHM, /**< Decryption operation failed due to unsupported algorithm*/
     FKO_ERROR_GPGME_BAD_GPG_EXE, /**< Unable to stat the given GPG executable*/

--- a/lib/fko_error.c
+++ b/lib/fko_error.c
@@ -420,7 +420,7 @@ fko_errstr(const int err_code)
             return("The key for the given signer was not found");
 
         case FKO_ERROR_GPGME_SIGNER_KEY_AMBIGUOUS:
-            return("Ambiguous name/id for the signer key (mulitple matches)");
+            return("Ambiguous name/id for the signer key (multiple matches)");
 
         case FKO_ERROR_GPGME_ADD_SIGNER:
             return("Error adding the signer key to the gpgme context");
@@ -435,7 +435,7 @@ fko_errstr(const int err_code)
             return("The key for the given recipient was not found");
 
         case FKO_ERROR_GPGME_RECIPIENT_KEY_AMBIGUOUS:
-            return("Ambiguous name/id for the recipient key (mulitple matches)");
+            return("Ambiguous name/id for the recipient key (multiple matches)");
 
         case FKO_ERROR_GPGME_DECRYPT_FAILED:
             return("Decryption operation failed");

--- a/server/access.c
+++ b/server/access.c
@@ -2108,7 +2108,7 @@ compare_port_list(acc_port_list_t *in, acc_port_list_t *ac, const int match_any)
     return(i_cnt == a_cnt);
 }
 
-/* Take a proto/port string (or mulitple comma-separated strings) and check
+/* Take a proto/port string (or multiple comma-separated strings) and check
  * them against the list for the given access stanza.
  *
  * Return 1 if we are allowed

--- a/server/access.h
+++ b/server/access.h
@@ -119,7 +119,7 @@ int compare_addr_list(acc_int_list_t *source_list, const uint32_t ip);
 /**
  * \brief Check for a proto-port string
  *
- * Take a proto/port string (or mulitple comma-separated strings) and check
+ * Take a proto/port string (or multiple comma-separated strings) and check
  * them against the list for the given access stanza.
  *
  * \param acc Pointer to the acc_stanza_t struct that holds the access stanzas

--- a/server/config_init.c
+++ b/server/config_init.c
@@ -1510,7 +1510,7 @@ usage(void)
       "                           back to UDP server mode if not used).\n"
 #endif
       " -O, --override-config   - Specify a file with configuration entries that will\n"
-      "                           overide those in fwknopd.conf\n"
+      "                           override those in fwknopd.conf\n"
       " -p, --pid-file          - Specify an alternate fwknopd.pid file.\n"
       " -P, --pcap-filter       - Specify a Berkeley packet filter statement to\n"
       "                           override the PCAP_FILTER variable in fwknopd.conf.\n"


### PR DESCRIPTION
found those flagged on https://lintian.debian.org/full/packages@qa.debian.org.html#fwknop_2.6.0-4 when I was reading up on the debian packaging process