### PR TITLE
[erlang] updating Erlang .gitignore and build dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ android/project/obj
 android/project/jni/fwknop/fko.h
 android/project/jni/libfwknop/*.h
 android/project/jni/libfwknop/*.c
+
+# Erlang
+erlang/_build
+erlang/rebar.lock

--- a/erlang/rebar.config
+++ b/erlang/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
 {deps,	[
-	{pkcs7, {git, "https://github.com/camshaft/pkcs7.erl"}}
+	{pkcs7, {git, "https://github.com/camshaft/pkcs7.erl"}, {branch, "master"}}
 	]
 }.

--- a/erlang/rebar.config
+++ b/erlang/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
 {deps,	[
-	{pkcs7, {git, "https://github.com/camshaft/pkcs7.erl"}, {branch, "master"}}
+	{pkcs7, {git, "https://github.com/camshaft/pkcs7.erl", {branch, "master"}}}
 	]
 }.

--- a/erlang/rebar.lock
+++ b/erlang/rebar.lock
@@ -1,4 +1,0 @@
-[{<<"pkcs7">>,
-  {git,"https://github.com/camshaft/pkcs7.erl",
-       {ref,"00218999ce9b60848aa1f36612248d1079c7ef06"}},
-  0}].


### PR DESCRIPTION
Updating project .gitignore for Erlang build artifacts, removing related rebar.lock, and explicitly setting pkcs7 dependency to master branch.