### PR TITLE
Let fwknop build on NetBSD

### DIFF
--- a/common/netinet_common.h
+++ b/common/netinet_common.h
@@ -45,7 +45,7 @@
   #if HAVE_NETINET_IN_H
     #include <netinet/in.h>
   #endif
-  #if PLATFORM_OPENBSD  /* OpenBSD hack due to autoconf net/if.h difficulties */
+  #if PLATFORM_NETBSD || PLATFORM_OPENBSD  /* for autoconf net/if.h difficulties */
     #include <net/if.h>
     #include <net/ethertypes.h>
     #include <netinet/if_ether.h>

--- a/configure.ac
+++ b/configure.ac
@@ -412,6 +412,9 @@ use_mingw=no
 case "$host" in
 *-*-linux*)
     ;;
+*-*-netbsd*)
+    AC_DEFINE_UNQUOTED([PLATFORM_NETBSD], [1], [Define if you are running on NetBSD])
+    ;;
 *-*-openbsd*)
     AC_DEFINE_UNQUOTED([PLATFORM_OPENBSD], [1], [Define if you are running on OpenBSD])
     ;;


### PR DESCRIPTION
This commit allows building fwknop on NetBSD. fwknop detects support for the pf(4) packet filter there, but was missing a definition for `ETHER_IS_VALID_LEN` in the standard headers. Using the same workaround as for OpenBSD bridged this gap.
I have not tested if this works.