### PR TITLE
Addressing most warnings

### DIFF
--- a/client/config_init.c
+++ b/client/config_init.c
@@ -514,7 +514,7 @@ is_rc_section(const char* line, uint16_t line_size, char* rc_section, uint16_t r
 
         ndx = buf;
 
-        while(isspace(*ndx))
+        while(isspace((int)(unsigned char)*ndx))
             ndx++;
 
         if(*ndx == '[')
@@ -761,7 +761,7 @@ parse_time_offset(const char *offset_str, int *offset)
 
     j=0;
     for (i=0; i < os_len; i++) {
-        if (isdigit(offset_str[i])) {
+        if (isdigit((int)(unsigned char)offset_str[i])) {
             offset_digits[j] = offset_str[i];
             j++;
             if(j >= MAX_TIME_STR_LEN)

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -749,7 +749,7 @@ set_nat_access(fko_ctx_t ctx, fko_cli_options_t *options, const char * const acc
     }
     ndx++;
 
-    while(*ndx != '\0' && isdigit(*ndx) && i < MAX_PORT_STR_LEN)
+    while(*ndx != '\0' && isdigit((int)(unsigned char)*ndx) && i < MAX_PORT_STR_LEN)
     {
         tmp_access_port[i] = *ndx;
         ndx++;
@@ -793,7 +793,7 @@ set_nat_access(fko_ctx_t ctx, fko_cli_options_t *options, const char * const acc
 
             {
                 tmp_nat_port[i] = *ndx;
-                if ((i > MAX_PORT_STR_LEN) || (!isdigit(*ndx)))
+                if ((i > MAX_PORT_STR_LEN) || (!isdigit((int)(unsigned char)*ndx)))
                 {
                     log_msg(LOG_VERBOSITY_ERROR, "[*] Invalid port value in -N arg.");
                     return FKO_ERROR_INVALID_DATA;

--- a/client/http_resolve_host.c
+++ b/client/http_resolve_host.c
@@ -202,7 +202,7 @@ try_url(struct url *url, fko_cli_options_t *options)
      *       (possibly followed by whitespace or other not-digit value).
      */
     for(i=0; i<MAX_IPV4_STR_LEN; i++) {
-        if(! isdigit(*(ndx+i)) && *(ndx+i) != '.')
+        if(! isdigit((int)(unsigned char)*(ndx+i)) && *(ndx+i) != '.')
             break;
     }
 
@@ -497,7 +497,7 @@ resolve_ip_https(fko_cli_options_t *options)
     {
         ndx = resp;
         for(i=0; i<MAX_IPV4_STR_LEN; i++) {
-            if(! isdigit(*(ndx+i)) && *(ndx+i) != '.')
+            if(! isdigit((int)(unsigned char)*(ndx+i)) && *(ndx+i) != '.')
                 break;
         }
         *(ndx+i) = '\0';

--- a/common/fko_util.c
+++ b/common/fko_util.c
@@ -149,7 +149,7 @@ is_valid_ipv4_addr(const char * const ip_str, const int len)
 
         if(*ndx == '.')
             dot_ctr++;
-        else if(isdigit(*ndx) == 0)
+        else if(isdigit((int)(unsigned char)*ndx) == 0)
         {
             res = 0;
             break;
@@ -196,17 +196,17 @@ is_valid_hostname(const char * const hostname_str, const int len)
 
         if (label_size == 0) //More restrictions on first character of a label
         {
-            if (!isalnum(*ndx))
+            if (!isalnum((int)(unsigned char)*ndx))
                 return 0;
         }
-        else if (!(isalnum(*ndx) | (*ndx == '.') | (*ndx == '-')))
+        else if (!(isalnum((int)(unsigned char)*ndx) | (*ndx == '.') | (*ndx == '-')))
             return 0;
 
         if (*ndx == '.')
         {
             if (label_size > 63)
                 return 0;
-            if (!isalnum(*(ndx-1)))  //checks that previous character was not a . or -
+            if (!isalnum((int)(unsigned char)*(ndx-1)))  //checks that previous character was not a . or -
                 return 0;
 
             label_size = 0;
@@ -776,7 +776,7 @@ strtoargv(const char * const args_str, char **argv_new, int *argc_new)
 
     for (i=0; i < (int)strlen(args_str); i++)
     {
-        if (!isspace(args_str[i]))
+        if (!isspace((int)(unsigned char)args_str[i]))
         {
             arg_tmp[current_arg_ctr] = args_str[i];
             current_arg_ctr++;

--- a/lib/fko_common.h
+++ b/lib/fko_common.h
@@ -95,7 +95,7 @@
   #include <endian.h>
   #if defined(BYTE_ORDER) /* POSIX proposal */
     #define BYTEORDER BYTE_ORDER
-  #elif #defined(__BYTE_ORDER) /* older systems? */
+  #elif defined(__BYTE_ORDER) /* older systems? */
     #define BYTEORDER __BYTE_ORDER
   #endif
 #elif HAVE_SYS_ENDIAN_H /* FreeBSD has a sys/endian.h */

--- a/lib/fko_decode.c
+++ b/lib/fko_decode.c
@@ -552,7 +552,7 @@ fko_decode_spa_data(fko_ctx_t ctx)
     /* Make sure there are no non-ascii printable chars
     */
     for (i=0; i < (int)strnlen(ctx->encoded_msg, MAX_SPA_ENCODED_MSG_SIZE); i++)
-        if(isprint(ctx->encoded_msg[i]) == 0)
+        if(isprint((int)(unsigned char)ctx->encoded_msg[i]) == 0)
             return(FKO_ERROR_INVALID_DATA_DECODE_NON_ASCII);
 
     /* Make sure there are enough fields in the SPA packet

--- a/lib/fko_message.c
+++ b/lib/fko_message.c
@@ -50,7 +50,7 @@ have_allow_ip(const char *msg)
         }
         if(*ndx == '.')
             dot_ctr++;
-        else if(isdigit(*ndx) == 0)
+        else if(isdigit((int)(unsigned char)*ndx) == 0)
         {
             res = FKO_ERROR_INVALID_ALLOW_IP;
             break;
@@ -83,13 +83,13 @@ have_port(const char *msg)
 
     /* Must have at least one digit for the port number
     */
-    if(isdigit(*ndx) == 0)
+    if(isdigit((int)(unsigned char)*ndx) == 0)
         return(FKO_ERROR_INVALID_SPA_ACCESS_MSG);
 
     while(*ndx != '\0' && *ndx != ',')
     {
         port_str_len++;
-        if((isdigit(*ndx) == 0) || (port_str_len > MAX_PORT_STR_LEN))
+        if((isdigit((int)(unsigned char)*ndx) == 0) || (port_str_len > MAX_PORT_STR_LEN))
             return(FKO_ERROR_INVALID_SPA_ACCESS_MSG);
         port_str[i] = *ndx;
         ndx++;

--- a/lib/fko_user.c
+++ b/lib/fko_user.c
@@ -175,7 +175,7 @@ validate_username(const char *username)
     */
     for (i=0; i < (int)strnlen(username, MAX_SPA_USERNAME_SIZE); i++)
     {
-        if((isalnum(username[i]) == 0)
+        if((isalnum((int)(unsigned char)username[i]) == 0)
                 && ((username[i] < 0x20 || username[i] > 0x7e)
                 /* Not allowed chars: " / \ [ ] : ; | = , + * ? < >
                 */

--- a/server/access.c
+++ b/server/access.c
@@ -524,7 +524,7 @@ expand_acc_int_list(acc_int_list_t **ilist, char *ip)
         {
             /* Skip over any leading whitespace.
             */
-            while(isspace(*start))
+            while(isspace((int)(unsigned char)*start))
                 start++;
 
             if(((ndx-start)+1) >= ACCESS_BUF_LEN)
@@ -542,7 +542,7 @@ expand_acc_int_list(acc_int_list_t **ilist, char *ip)
 
     /* Skip over any leading whitespace (once again for the last in the list).
     */
-    while(isspace(*start))
+    while(isspace((int)(unsigned char)*start))
         start++;
 
     if(((ndx-start)+1) >= ACCESS_BUF_LEN)
@@ -716,7 +716,7 @@ expand_acc_port_list(acc_port_list_t **plist, char *plist_str)
         {
             /* Skip over any leading whitespace.
             */
-            while(isspace(*start))
+            while(isspace((int)(unsigned char)*start))
                 start++;
 
             if(((ndx-start)+1) >= ACCESS_BUF_LEN)
@@ -733,7 +733,7 @@ expand_acc_port_list(acc_port_list_t **plist, char *plist_str)
 
     /* Skip over any leading whitespace (once again for the last in the list).
     */
-    while(isspace(*start))
+    while(isspace((int)(unsigned char)*start))
         start++;
 
     if(((ndx-start)+1) >= ACCESS_BUF_LEN)
@@ -763,7 +763,7 @@ expand_acc_string_list(acc_string_list_t **stlist, char *stlist_str)
         {
             /* Skip over any leading whitespace.
             */
-            while(isspace(*start))
+            while(isspace((int)(unsigned char)*start))
                 start++;
 
             if(((ndx-start)+1) >= MAX_LINE_LEN)
@@ -779,7 +779,7 @@ expand_acc_string_list(acc_string_list_t **stlist, char *stlist_str)
 
     /* Skip over any leading whitespace (once again for the last in the list).
     */
-    while(isspace(*start))
+    while(isspace((int)(unsigned char)*start))
         start++;
 
     if(((ndx-start)+1) >= MAX_LINE_LEN)

--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -112,7 +112,7 @@ preprocess_spa_data(const fko_srv_options_t *opts, spa_pkt_info_t *spa_pkt, spa_
             xff += 17;
 
             for (i = 0; *xff != '\0'; i++)
-                if (isspace(*xff))
+                if (isspace((int)(unsigned char)*xff))
                    *xff = '\0';
                 else
                    xff++;
@@ -135,7 +135,7 @@ preprocess_spa_data(const fko_srv_options_t *opts, spa_pkt_info_t *spa_pkt, spa_
 
         for(i=0; i<pkt_data_len; i++)
         {
-            if(isspace(*ndx)) /* The first space marks the end of the req */
+            if(isspace((int)(unsigned char)*ndx)) /* The first space marks the end of the req */
             {
                 *ndx = '\0';
                 break;

--- a/server/utils.c
+++ b/server/utils.c
@@ -212,7 +212,7 @@ is_digits(const char * const str)
     {
         for (i=0; i<strlen(str); i++)
         {
-            if(!isdigit(str[i]))
+            if(!isdigit((int)(unsigned char)str[i]))
                 return 0;
             i++;
         }


### PR DESCRIPTION
These two commits address two types of warnings:

- an issue with the pre-processor (apparently a harmless typo)
- issues with functions from ctype(3) potentially revealing actual bugs.