### PR TITLE
Allow connecting to remote IPv6 hosts for TCP or UDP

### DIFF
--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -98,7 +98,7 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
 
     memset(&hints, 0, sizeof(struct addrinfo));
 
-    hints.ai_family   = AF_INET; /* Allow IPv4 only */
+    hints.ai_family   = AF_UNSPEC;
 
     if (options->spa_proto == FKO_PROTO_UDP)
     {


### PR DESCRIPTION
This alone should allow interacting with IPv4 firewalling rules over
IPv6, for these two protocols.

Addresses part of #1.