### PR TITLE
Use HTTP/1.1 when communicating over HTTP

### DIFF
--- a/client/http_resolve_host.c
+++ b/client/http_resolve_host.c
@@ -83,7 +83,7 @@ try_url(struct url *url, fko_cli_options_t *options)
      * to contacting whatismyip.org, but using a different URL).
     */
     snprintf(http_buf, HTTP_MAX_REQUEST_LEN,
-        "GET %s HTTP/1.0\r\nUser-Agent: %s\r\nAccept: */*\r\n"
+        "GET %s HTTP/1.1\r\nUser-Agent: %s\r\nAccept: */*\r\n"
         "Host: %s\r\nConnection: close\r\n\r\n",
         url->path,
         options->http_user_agent,

--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -546,7 +546,7 @@ send_spa_packet_http(const char *spa_data, const int sd_len,
     if(options->http_proxy[0] == 0x0)
     {
         snprintf(http_buf, HTTP_MAX_REQUEST_LEN,
-            "GET /%s HTTP/1.0\r\nUser-Agent: %s\r\nAccept: */*\r\n"
+            "GET /%s HTTP/1.1\r\nUser-Agent: %s\r\nAccept: */*\r\n"
             "Host: %s\r\nConnection: close\r\n\r\n",
             spa_data_copy,
             options->http_user_agent,

--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -587,7 +587,7 @@ send_spa_packet_http(const char *spa_data, const int sd_len,
             options->spa_dst_port = proxy_port;
 
         snprintf(http_buf, HTTP_MAX_REQUEST_LEN,
-            "GET http://%s/%s HTTP/1.0\r\nUser-Agent: %s\r\nAccept: */*\r\n"
+            "GET http://%s/%s HTTP/1.1\r\nUser-Agent: %s\r\nAccept: */*\r\n"
             "Host: %s\r\nConnection: close\r\n\r\n",
             options->spa_server_str,
             spa_data_copy,


### PR DESCRIPTION
For some reason the HTTP headers generated for GET requests in the client code are using HTTP/1.0, whereas the "Host" header is always provided anyway. It seems to me that it should do no harm to use HTTP/1.1 instead (not tested).