### PR TITLE
Support for IPv6 (1/x)

### DIFF
--- a/client/fwknop_common.h
+++ b/client/fwknop_common.h
@@ -87,8 +87,8 @@ typedef struct fko_cli_options
     int  no_save_args;
     int  use_hmac;
     char spa_server_str[MAX_SERVER_STR_LEN];  /* may be a hostname */
-    char allow_ip_str[MAX_IPV4_STR_LEN];
-    char spoof_ip_src_str[MAX_IPV4_STR_LEN];
+    char allow_ip_str[MAX_IPV46_STR_LEN];
+    char spoof_ip_src_str[MAX_IPV46_STR_LEN];
     char spoof_user[MAX_USERNAME_LEN];
     int  rand_port;
     char gpg_recipient_key[MAX_GPG_KEY_ID];

--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -230,7 +230,7 @@ send_spa_packet_tcp_raw(const char *spa_data, const int sd_len,
         return res;
     }
 
-    sock = socket (PF_INET, SOCK_RAW, IPPROTO_RAW);
+    sock = socket (AF_INET, SOCK_RAW, IPPROTO_RAW);
     if (sock < 0)
     {
         log_msg(LOG_VERBOSITY_ERROR, "send_spa_packet_tcp_raw: create socket: ", strerror(errno));
@@ -343,7 +343,7 @@ send_spa_packet_udp_raw(const char *spa_data, const int sd_len,
         return res;
     }
 
-    sock = socket (PF_INET, SOCK_RAW, IPPROTO_RAW);
+    sock = socket (AF_INET, SOCK_RAW, IPPROTO_RAW);
     if (sock < 0)
     {
         log_msg(LOG_VERBOSITY_ERROR, "send_spa_packet_udp_raw: create socket: ", strerror(errno));
@@ -441,7 +441,7 @@ send_spa_packet_icmp(const char *spa_data, const int sd_len,
         return res;
     }
 
-    sock = socket (PF_INET, SOCK_RAW, IPPROTO_RAW);
+    sock = socket (AF_INET, SOCK_RAW, IPPROTO_RAW);
 
     if (sock < 0)
     {

--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -98,7 +98,7 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
 
     memset(&hints, 0, sizeof(struct addrinfo));
 
-    hints.ai_family   = AF_INET; /* Allow IPv4 only */
+    hints.ai_family   = AF_UNSPEC;
 
     if (options->spa_proto == FKO_PROTO_UDP)
     {

--- a/configure.ac
+++ b/configure.ac
@@ -356,7 +356,15 @@ AC_HEADER_STDC
 AC_HEADER_TIME
 AC_HEADER_RESOLV
 
-AC_CHECK_HEADERS([arpa/inet.h ctype.h endian.h errno.h locale.h netdb.h net/ethernet.h netinet/in.h stdint.h stdlib.h string.h strings.h sys/byteorder.h sys/endian.h sys/ethernet.h sys/socket.h sys/stat.h sys/time.h sys/wait.h termios.h time.h unistd.h])
+AC_CHECK_HEADERS([arpa/inet.h ctype.h endian.h errno.h locale.h netdb.h net/ethernet.h netinet/in.h stdint.h stdlib.h string.h strings.h sys/byteorder.h sys/endian.h sys/ethernet.h sys/socket.h sys/stat.h sys/time.h sys/types.h sys/wait.h termios.h time.h unistd.h])
+AC_CHECK_HEADERS([netinet/ip6.h netinet/icmp6.h], [], [],
+[#ifdef HAVE_SYS_TYPES_H
+# include <sys/types.h>
+#endif
+#ifdef HAVE_NETINET_IN_H
+# include <netinet/in.h>
+#endif
+])
 
 # Type checks.
 #

--- a/lib/fko_limits.h
+++ b/lib/fko_limits.h
@@ -59,6 +59,12 @@
 #define MAX_IPV4_STR_LEN             16
 #define MIN_IPV4_STR_LEN              7
 
+#define MAX_IPV46_STR_LEN            40
+#define MIN_IPV46_STR_LEN             3
+
+#define MAX_IPV6_STR_LEN             40
+#define MIN_IPV6_STR_LEN              3
+
 #define MAX_PROTO_STR_LEN             4  /* tcp, udp, icmp for now */
 #define MAX_PORT_STR_LEN              5
 #define MAX_PORT                  65535

--- a/server/access.c
+++ b/server/access.c
@@ -373,9 +373,8 @@ add_int_ent(acc_int_list_t **ilist, const char *ip)
     */
     if(strcasecmp(ip, "ANY") == 0)
     {
-        new_sle->family = AF_INET;
-        new_sle->acc_int.inet.maddr = 0x0;
-        new_sle->acc_int.inet.mask = 0x0;
+        new_sle->family = AF_UNSPEC;
+        memset(&new_sle->acc_int, 0, sizeof(new_sle->acc_int));
     }
     else
     {
@@ -2094,6 +2093,8 @@ compare_addr_list(acc_int_list_t *ip_list, int family, ...)
     va_end(ap);
     while(ip_list)
     {
+        if(ip_list->family == AF_UNSPEC)
+            return 1;
         if(ip_list->family != family)
         {
             ip_list = ip_list->next;

--- a/server/access.h
+++ b/server/access.h
@@ -114,7 +114,7 @@ int valid_access_stanzas(acc_stanza_t *acc);
  * \return Returns true on a match
  *
  */
-int compare_addr_list(acc_int_list_t *source_list, const uint32_t ip);
+int compare_addr_list(acc_int_list_t *source_list, int family, ...);
 
 /**
  * \brief Check for a proto-port string

--- a/server/cmd_opts.h
+++ b/server/cmd_opts.h
@@ -181,9 +181,9 @@ enum {
 /* Our getopt_long options string.
 */
 #if USE_LIBNETFILTER_QUEUE
-  #define GETOPTS_OPTION_STRING "Aa:c:C:d:Dfhi:Kl:nO:p:P:Rr:StUvV"
+  #define GETOPTS_OPTION_STRING "Aa:c:C:d:Dfhi:6Kl:nO:p:P:Rr:StUvV"
 #else
-  #define GETOPTS_OPTION_STRING "Aa:c:C:d:Dfhi:Kl:O:p:P:Rr:StUvV"
+  #define GETOPTS_OPTION_STRING "Aa:c:C:d:Dfhi:6Kl:O:p:P:Rr:StUvV"
 #endif
 
 /* Our program command-line options...
@@ -206,6 +206,7 @@ static struct option cmd_opts[] =
     {"fault-injection-tag",     1, NULL, FAULT_INJECTION_TAG},
     {"help",                    0, NULL, 'h'},
     {"interface",               1, NULL, 'i'},
+    {"ipv6",                    0, NULL, '6'},
     {"key-gen",                 0, NULL, 'k'},
     {"key-gen-file",            1, NULL, KEY_GEN_FILE },
     {"key-len",                 1, NULL, KEY_LEN },

--- a/server/config_init.c
+++ b/server/config_init.c
@@ -1372,6 +1372,9 @@ config_init(fko_srv_options_t *opts, int argc, char **argv)
             case 'i':
                 set_config_entry(opts, CONF_PCAP_INTF, optarg);
                 break;
+	    case '6':
+		opts->ipv6 = 1;
+		break;
             case FIREWD_DISABLE_CHECK_SUPPORT:
                 opts->firewd_disable_check_support = 1;
                 break;
@@ -1498,6 +1501,7 @@ usage(void)
       "                           a background daemon).\n"
       " -i, --interface         - Specify interface to listen for incoming SPA\n"
       "                           packets.\n"
+      " -6, --ipv6              - Start the server in IPv6 mode (TCP/UDP).\n"
       " -C, --packet-limit      - Limit the number of candidate SPA packets to\n"
       "                           process and exit when this limit is reached.\n"
       " -d, --digest-file       - Specify an alternate digest.cache file.\n"

--- a/server/fwknopd.c
+++ b/server/fwknopd.c
@@ -259,7 +259,7 @@ main(int argc, char **argv)
         if(opts.enable_udp_server ||
                 strncasecmp(opts.config[CONF_ENABLE_UDP_SERVER], "Y", 1) == 0)
         {
-            if(run_udp_server(&opts, AF_INET) < 0)
+            if(run_udp_server(&opts, opts.ipv6 ? AF_INET6 : AF_INET) < 0)
             {
                 log_msg(LOG_ERR, "Fatal run_udp_server() error");
                 clean_exit(&opts, FW_CLEANUP, EXIT_FAILURE);
@@ -280,7 +280,7 @@ main(int argc, char **argv)
         */
         if(strncasecmp(opts.config[CONF_ENABLE_TCP_SERVER], "Y", 1) == 0)
         {
-            if(run_tcp_server(&opts, AF_INET) < 0)
+            if(run_tcp_server(&opts, opts.ipv6 ? AF_INET6 : AF_INET) < 0)
             {
                 log_msg(LOG_ERR, "Fatal run_tcp_server() error");
                 clean_exit(&opts, FW_CLEANUP, EXIT_FAILURE);

--- a/server/fwknopd.c
+++ b/server/fwknopd.c
@@ -259,7 +259,7 @@ main(int argc, char **argv)
         if(opts.enable_udp_server ||
                 strncasecmp(opts.config[CONF_ENABLE_UDP_SERVER], "Y", 1) == 0)
         {
-            if(run_udp_server(&opts) < 0)
+            if(run_udp_server(&opts, AF_INET) < 0)
             {
                 log_msg(LOG_ERR, "Fatal run_udp_server() error");
                 clean_exit(&opts, FW_CLEANUP, EXIT_FAILURE);
@@ -280,7 +280,7 @@ main(int argc, char **argv)
         */
         if(strncasecmp(opts.config[CONF_ENABLE_TCP_SERVER], "Y", 1) == 0)
         {
-            if(run_tcp_server(&opts) < 0)
+            if(run_tcp_server(&opts, AF_INET) < 0)
             {
                 log_msg(LOG_ERR, "Fatal run_tcp_server() error");
                 clean_exit(&opts, FW_CLEANUP, EXIT_FAILURE);

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -685,6 +685,7 @@ typedef struct fko_srv_options
     unsigned char   enable_nfq_capture; /* Enable Netfilter Queue capture mode */
     unsigned char   enable_fw;          /* Command modes by themselves don't
                                            need firewall support. */
+    unsigned char   ipv6;		/* Enable IPv6 mode (TCP/UDP) */
 
     unsigned char   firewd_disable_check_support; /* Don't use firewall-cmd ... -C */
     unsigned char   ipt_disable_check_support;    /* Don't use iptables -C */

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -632,10 +632,10 @@ typedef struct spa_data
     char           *version;
     short           message_type;
     char           *spa_message;
-    char            spa_message_src_ip[MAX_IPV4_STR_LEN];
-    char            pkt_source_ip[MAX_IPV4_STR_LEN];
-    char            pkt_source_xff_ip[MAX_IPV4_STR_LEN];
-    char            pkt_destination_ip[MAX_IPV4_STR_LEN];
+    char            spa_message_src_ip[MAX_IPV46_STR_LEN];
+    char            pkt_source_ip[MAX_IPV46_STR_LEN];
+    char            pkt_source_xff_ip[MAX_IPV46_STR_LEN];
+    char            pkt_destination_ip[MAX_IPV46_STR_LEN];
     char            spa_message_remain[1024]; /* --DSS FIXME: arbitrary bounds */
     char           *nat_access;
     char           *server_auth;

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -600,12 +600,28 @@ typedef struct spa_pkt_info
 {
     unsigned int    packet_data_len;
     unsigned int    packet_proto;
-    unsigned int    packet_src_ip;
-    unsigned int    packet_dst_ip;
+    unsigned int    packet_family;
+    union
+    {
+	    struct
+	    {
+		    unsigned int src_ip;
+		    unsigned int dst_ip;
+	    } inet;
+#if HAVE_NETINET_IP6_H
+	    struct
+	    {
+		    struct in6_addr src_ip;
+		    struct in6_addr dst_ip;
+	    } inet6;
+#endif
+    } packet_addr;
     unsigned short  packet_src_port;
     unsigned short  packet_dst_port;
     unsigned char   packet_data[MAX_SPA_PACKET_LEN+1];
 } spa_pkt_info_t;
+#define packet_src_ip packet_addr.inet.src_ip
+#define packet_dst_ip packet_addr.inet.dst_ip
 
 /* Struct for (processed and verified) SPA data used by the server.
 */

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -358,8 +358,20 @@ enum {
 */
 typedef struct acc_int_list
 {
-    unsigned int        maddr;
-    unsigned int        mask;
+    int family;
+    union
+    {
+        struct
+	{
+	    unsigned int        maddr;
+	    unsigned int        mask;
+	} inet;
+        struct
+	{
+	    struct in6_addr     maddr;
+	    unsigned int        prefix;
+	} inet6;
+    } acc_int;
     struct acc_int_list *next;
 } acc_int_list_t;
 

--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -254,7 +254,7 @@ get_raw_digest(char **digest, char *pkt_data)
     return res;
 }
 
-/* Popluate a spa_data struct from an initialized (and populated) FKO context.
+/* Populate a spa_data struct from an initialized (and populated) FKO context.
 */
 static int
 get_spa_data_fields(fko_ctx_t ctx, spa_data_t *spdat)

--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -347,14 +347,28 @@ check_stanza_expiration(acc_stanza_t *acc, spa_data_t *spadat,
  * source IP
 */
 static int
-is_src_match(acc_stanza_t *acc, const uint32_t ip)
+is_src_match(acc_stanza_t *acc, const spa_pkt_info_t *spa_pkt)
 {
-    while (acc)
+    switch (spa_pkt->packet_family)
     {
-        if(compare_addr_list(acc->source_list, ip))
-            return 1;
+        case AF_INET:
+            while (acc)
+            {
+                if(compare_addr_list(acc->source_list, AF_INET, ntohl(spa_pkt->packet_addr.inet.src_ip)))
+                    return 1;
 
-        acc = acc->next;
+                acc = acc->next;
+            }
+            break;
+        case AF_INET6:
+            while (acc)
+            {
+                if(compare_addr_list(acc->source_list, AF_INET6, &spa_pkt->packet_addr.inet6.src_ip))
+                    return 1;
+
+                acc = acc->next;
+            }
+            break;
     }
     return 0;
 }
@@ -363,7 +377,7 @@ static int
 src_check(fko_srv_options_t *opts, spa_pkt_info_t *spa_pkt,
         spa_data_t *spadat, char **raw_digest)
 {
-    if (is_src_match(opts->acc_stanzas, ntohl(spa_pkt->packet_src_ip)))
+    if (is_src_match(opts->acc_stanzas, spa_pkt))
     {
         if(strncasecmp(opts->config[CONF_ENABLE_DIGEST_PERSISTENCE], "Y", 1) == 0)
         {
@@ -427,9 +441,9 @@ static int
 src_dst_check(acc_stanza_t *acc, spa_pkt_info_t *spa_pkt,
         spa_data_t *spadat, const int stanza_num)
 {
-    if(! compare_addr_list(acc->source_list, ntohl(spa_pkt->packet_src_ip)) ||
+    if(! compare_addr_list(acc->source_list, AF_INET, ntohl(spa_pkt->packet_src_ip)) ||
        (acc->destination_list != NULL
-        && ! compare_addr_list(acc->destination_list, ntohl(spa_pkt->packet_dst_ip))))
+        && ! compare_addr_list(acc->destination_list, AF_INET, ntohl(spa_pkt->packet_dst_ip))))
     {
         log_msg(LOG_DEBUG,
                 "(stanza #%d) SPA packet (%s -> %s) filtered by SOURCE and/or DESTINATION criteria",

--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -930,10 +930,10 @@ incoming_spa(fko_srv_options_t *opts)
     */
     acc_stanza_t        *acc = opts->acc_stanzas;
 
-    inet_ntop(AF_INET, &(spa_pkt->packet_src_ip),
+    inet_ntop(spa_pkt->packet_family, &(spa_pkt->packet_src_ip),
         spadat.pkt_source_ip, sizeof(spadat.pkt_source_ip));
 
-    inet_ntop(AF_INET, &(spa_pkt->packet_dst_ip),
+    inet_ntop(spa_pkt->packet_family, &(spa_pkt->packet_dst_ip),
         spadat.pkt_destination_ip, sizeof(spadat.pkt_destination_ip));
 
     /* At this point, we want to validate and (if needed) preprocess the

--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -944,11 +944,25 @@ incoming_spa(fko_srv_options_t *opts)
     */
     acc_stanza_t        *acc = opts->acc_stanzas;
 
-    inet_ntop(spa_pkt->packet_family, &(spa_pkt->packet_src_ip),
-        spadat.pkt_source_ip, sizeof(spadat.pkt_source_ip));
+    switch(spa_pkt->packet_family)
+    {
+        case AF_INET:
+            inet_ntop(AF_INET, &(spa_pkt->packet_addr.inet.src_ip),
+                spadat.pkt_source_ip, sizeof(spadat.pkt_source_ip));
 
-    inet_ntop(spa_pkt->packet_family, &(spa_pkt->packet_dst_ip),
-        spadat.pkt_destination_ip, sizeof(spadat.pkt_destination_ip));
+            inet_ntop(AF_INET, &(spa_pkt->packet_addr.inet.dst_ip),
+                spadat.pkt_destination_ip, sizeof(spadat.pkt_destination_ip));
+            break;
+        case AF_INET6:
+            inet_ntop(AF_INET6, &(spa_pkt->packet_addr.inet6.src_ip),
+                spadat.pkt_source_ip, sizeof(spadat.pkt_source_ip));
+
+            inet_ntop(AF_INET6, &(spa_pkt->packet_addr.inet6.dst_ip),
+                spadat.pkt_destination_ip, sizeof(spadat.pkt_destination_ip));
+            break;
+        default:
+            return;
+    }
 
     /* At this point, we want to validate and (if needed) preprocess the
      * SPA data and/or to be reasonably sure we have a SPA packet (i.e

--- a/server/pcap_capture.c
+++ b/server/pcap_capture.c
@@ -211,7 +211,7 @@ pcap_capture(fko_srv_options_t *opts)
 
                     /* Attempt to restart tcp server ? */
                     usleep(1000000);
-                    run_tcp_server(opts, AF_INET);
+                    run_tcp_server(opts, opts->ipv6 ? AF_INET6 : AF_INET);
                 }
             }
 

--- a/server/pcap_capture.c
+++ b/server/pcap_capture.c
@@ -211,7 +211,7 @@ pcap_capture(fko_srv_options_t *opts)
 
                     /* Attempt to restart tcp server ? */
                     usleep(1000000);
-                    run_tcp_server(opts);
+                    run_tcp_server(opts, AF_INET);
                 }
             }
 

--- a/server/process_packet.c
+++ b/server/process_packet.c
@@ -263,14 +263,13 @@ process_packet_ipv4(fko_srv_options_t * opts, const unsigned char * packet,
     strlcpy((char *)opts->spa_pkt.packet_data, (char *)pkt_data, pkt_data_len+1);
     opts->spa_pkt.packet_data_len = pkt_data_len;
     opts->spa_pkt.packet_proto    = proto;
+    opts->spa_pkt.packet_family   = AF_INET;
     opts->spa_pkt.packet_src_ip   = src_ip;
     opts->spa_pkt.packet_dst_ip   = dst_ip;
     opts->spa_pkt.packet_src_port = src_port;
     opts->spa_pkt.packet_dst_port = dst_port;
 
     incoming_spa(opts);
-
-    return;
 }
 
 

--- a/server/process_packet.c
+++ b/server/process_packet.c
@@ -41,49 +41,60 @@
 #include "log_msg.h"
 
 
+static void
+process_packet_ethernet(fko_srv_options_t * opts, const unsigned char * packet,
+		unsigned short pkt_len, int caplen, int offset);
+static void
+process_packet_ipv4(fko_srv_options_t * opts, const unsigned char * packet,
+		int offset, unsigned char * fr_end);
+static void
+process_packet_ipv6(fko_srv_options_t * opts, const unsigned char * packet,
+		int offset, unsigned char * fr_end);
+static void
+process_packet_raw(fko_srv_options_t * opts, const unsigned char * packet);
+
+
 void
 process_packet(PROCESS_PKT_ARGS_TYPE *args, PACKET_HEADER_META,
                const unsigned char *packet)
 {
-    struct ether_header *eth_p;
-    struct iphdr        *iph_p;
-    struct tcphdr       *tcph_p;
-    struct udphdr       *udph_p;
-    struct icmphdr      *icmph_p;
-
-    unsigned char       *pkt_data;
-    unsigned short      pkt_data_len;
-    unsigned char       *pkt_end;
-    unsigned char       *fr_end;
-
-    unsigned int        ip_hdr_words;
-
-    unsigned char       proto;
-    unsigned int        src_ip;
-    unsigned int        dst_ip;
-
-    unsigned short      src_port = 0;
-    unsigned short      dst_port = 0;
-
-    unsigned short      eth_type;
-
     fko_srv_options_t   *opts = (fko_srv_options_t *)args;
 
     int                 offset = opts->data_link_offset;
 
+    if (offset != 0)
 #if USE_LIBPCAP
-    unsigned short      pkt_len = packet_header->len;
+	process_packet_ethernet(opts, packet, packet_header->len,
+			packet_header->caplen, offset);
+#else
+	process_packet_ethernet(opts, packet, pkt_len, pkt_len, offset);
+#endif
+    else
+	process_packet_raw(opts, packet);
+}
 
+
+static void
+process_packet_ethernet(fko_srv_options_t * opts, const unsigned char * packet,
+		unsigned short pkt_len, int caplen, int offset)
+{
+    struct ether_header *eth_p;
+
+    unsigned char       *fr_end;
+
+    unsigned short      eth_type;
+
+#if USE_LIBPCAP
     /* Gotta have a complete ethernet header.
     */
-    if (packet_header->caplen < ETHER_HDR_LEN)
+    if (caplen < ETHER_HDR_LEN)
         return;
 
     /* Determine packet end.
     */
-    fr_end = (unsigned char *) packet + packet_header->caplen;
+    fr_end = (unsigned char *) packet + caplen;
 #else
-    /* This is coming from NFQ and we get the packet lentgh as an arg.
+    /* This is coming from NFQ and we get the packet length as an arg.
     */
     if (pkt_len < ETHER_HDR_LEN)
         return;
@@ -126,6 +137,35 @@ process_packet(PROCESS_PKT_ARGS_TYPE *args, PACKET_HEADER_META,
     */
     if (! ETHER_IS_VALID_LEN(pkt_len) )
         return;
+
+    if (eth_type == ETHERTYPE_IP)
+	process_packet_ipv4(opts, packet, offset, fr_end);
+    else if (eth_type == ETHERTYPE_IPV6)
+	process_packet_ipv6(opts, packet, offset, fr_end);
+}
+
+
+static void
+process_packet_ipv4(fko_srv_options_t * opts, const unsigned char * packet,
+		int offset, unsigned char * fr_end)
+{
+    struct iphdr        *iph_p;
+    struct tcphdr       *tcph_p;
+    struct udphdr       *udph_p;
+    struct icmphdr      *icmph_p;
+
+    unsigned char       *pkt_data;
+    unsigned short      pkt_data_len;
+    unsigned char       *pkt_end;
+
+    unsigned int        ip_hdr_words;
+
+    unsigned char       proto;
+    unsigned int        src_ip;
+    unsigned int        dst_ip;
+
+    unsigned short      src_port = 0;
+    unsigned short      dst_port = 0;
 
     /* Pull the IP header.
     */
@@ -231,6 +271,21 @@ process_packet(PROCESS_PKT_ARGS_TYPE *args, PACKET_HEADER_META,
     incoming_spa(opts);
 
     return;
+}
+
+
+static void
+process_packet_ipv6(fko_srv_options_t * opts, const unsigned char * packet,
+		int offset, unsigned char * fr_end)
+{
+    /* FIXME implement */
+}
+
+
+static void
+process_packet_raw(fko_srv_options_t * opts, const unsigned char * packet)
+{
+    /* FIXME implement */
 }
 
 

--- a/server/process_packet.c
+++ b/server/process_packet.c
@@ -46,12 +46,16 @@ process_packet_ethernet(fko_srv_options_t * opts, const unsigned char * packet,
 		unsigned short pkt_len, int caplen, int offset);
 static void
 process_packet_ipv4(fko_srv_options_t * opts, const unsigned char * packet,
-		int offset, unsigned char * fr_end);
+		int offset, unsigned char const * fr_end);
 static void
 process_packet_ipv6(fko_srv_options_t * opts, const unsigned char * packet,
-		int offset, unsigned char * fr_end);
+		int offset, unsigned char const * fr_end);
 static void
-process_packet_raw(fko_srv_options_t * opts, const unsigned char * packet);
+process_packet_loop(fko_srv_options_t * opts, const unsigned char * packet,
+		unsigned short pkt_len, int caplen);
+static void
+process_packet_raw(fko_srv_options_t * opts, const unsigned char * packet,
+		unsigned short pkt_len, int caplen);
 
 
 void
@@ -62,15 +66,19 @@ process_packet(PROCESS_PKT_ARGS_TYPE *args, PACKET_HEADER_META,
 
     int                 offset = opts->data_link_offset;
 
-    if (offset != 0)
 #if USE_LIBPCAP
+    if (offset == sizeof(struct ether_header))
 	process_packet_ethernet(opts, packet, packet_header->len,
 			packet_header->caplen, offset);
+    else if (offset == 4)
+	process_packet_loop(opts, packet, packet_header->len,
+			packet_header->caplen);
+    else if (offset == 0)
+	process_packet_raw(opts, packet, packet_header->len,
+			packet_header->caplen);
 #else
-	process_packet_ethernet(opts, packet, pkt_len, pkt_len, offset);
+    process_packet_raw(opts, packet, pkt_len, pkt_len);
 #endif
-    else
-	process_packet_raw(opts, packet);
 }
 
 
@@ -84,7 +92,6 @@ process_packet_ethernet(fko_srv_options_t * opts, const unsigned char * packet,
 
     unsigned short      eth_type;
 
-#if USE_LIBPCAP
     /* Gotta have a complete ethernet header.
     */
     if (caplen < ETHER_HDR_LEN)
@@ -93,13 +100,6 @@ process_packet_ethernet(fko_srv_options_t * opts, const unsigned char * packet,
     /* Determine packet end.
     */
     fr_end = (unsigned char *) packet + caplen;
-#else
-    /* This is coming from NFQ and we get the packet length as an arg.
-    */
-    if (pkt_len < ETHER_HDR_LEN)
-        return;
-    fr_end = (unsigned char *) packet + pkt_len;
-#endif
 
     /* This is a hack to determine if we are using the linux cooked
      * interface.  We base it on the offset being 16 which is the
@@ -147,7 +147,7 @@ process_packet_ethernet(fko_srv_options_t * opts, const unsigned char * packet,
 
 static void
 process_packet_ipv4(fko_srv_options_t * opts, const unsigned char * packet,
-		int offset, unsigned char * fr_end)
+		int offset, unsigned char const * fr_end)
 {
     struct iphdr        *iph_p;
     struct tcphdr       *tcph_p;
@@ -276,16 +276,62 @@ process_packet_ipv4(fko_srv_options_t * opts, const unsigned char * packet,
 
 static void
 process_packet_ipv6(fko_srv_options_t * opts, const unsigned char * packet,
-		int offset, unsigned char * fr_end)
+		int offset, unsigned char const * fr_end)
 {
     /* FIXME implement */
 }
 
 
 static void
-process_packet_raw(fko_srv_options_t * opts, const unsigned char * packet)
+process_packet_loop(fko_srv_options_t * opts, const unsigned char * packet,
+		unsigned short pkt_len, int caplen)
 {
-    /* FIXME implement */
+    uint32_t family;
+
+    if (caplen < sizeof(family))
+	return;
+
+    memcpy(&family, packet, sizeof(family));
+
+    if (family == AF_INET)
+	process_packet_ipv4(opts, packet, 4, packet + caplen);
+    else if (family == AF_INET6)
+	process_packet_ipv6(opts, packet, 4, packet + caplen);
+}
+
+
+static void
+process_packet_raw(fko_srv_options_t * opts, const unsigned char * packet,
+		unsigned short pkt_len, int caplen)
+{
+    struct iphdr        *iph_p;
+
+    unsigned char const *fr_end;
+
+    /* Gotta have a complete ethernet header.
+    */
+    if (caplen < ETHER_HDR_LEN)
+        return;
+
+    /* Determine packet end.
+    */
+    fr_end = (unsigned char *) packet + caplen;
+
+    /* Tentatively pull an IP header.
+    */
+    iph_p = (struct iphdr*)packet;
+
+    /* If IP header is past calculated packet end, bail.
+    */
+    if ((unsigned char*)(iph_p + 1) > fr_end)
+        return;
+
+    /* Obtain the IP version.
+    */
+    if (iph_p->version == 6)
+	    process_packet_ipv6(opts, packet, 0, fr_end);
+    else
+	    process_packet_ipv4(opts, packet, 0, fr_end);
 }
 
 

--- a/server/tcp_server.c
+++ b/server/tcp_server.c
@@ -51,9 +51,8 @@
  * the child process or -1 if there is a fork error.
 */
 int
-run_tcp_server(fko_srv_options_t *opts)
+run_tcp_server(fko_srv_options_t *opts, int family)
 {
-    const int           family = AF_INET;
 #if !CODE_COVERAGE
     pid_t               pid, ppid;
 #endif

--- a/server/tcp_server.c
+++ b/server/tcp_server.c
@@ -53,6 +53,7 @@
 int
 run_tcp_server(fko_srv_options_t *opts)
 {
+    const int           family = AF_INET;
 #if !CODE_COVERAGE
     pid_t               pid, ppid;
 #endif
@@ -94,7 +95,7 @@ run_tcp_server(fko_srv_options_t *opts)
 
     /* Now, let's make a TCP server
     */
-    if ((s_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0)
+    if ((s_sock = socket(family, SOCK_STREAM, IPPROTO_TCP)) < 0)
     {
         log_msg(LOG_ERR, "run_tcp_server: socket() failed: %s",
             strerror(errno));
@@ -136,7 +137,7 @@ run_tcp_server(fko_srv_options_t *opts)
 
     /* Construct local address structure */
     memset(&saddr, 0, sizeof(saddr));
-    saddr.sin_family      = AF_INET;           /* Internet address family */
+    saddr.sin_family      = family;            /* Internet address family */
     saddr.sin_addr.s_addr = htonl(INADDR_ANY); /* Any incoming interface */
     saddr.sin_port        = htons(opts->tcpserv_port);  /* Local port */
 
@@ -226,7 +227,7 @@ run_tcp_server(fko_srv_options_t *opts)
         if(opts->verbose)
         {
             memset(sipbuf, 0x0, sizeof(sipbuf));
-            inet_ntop(AF_INET, &(caddr.sin_addr.s_addr), sipbuf, sizeof(sipbuf));
+            inet_ntop(family, &(caddr.sin_addr.s_addr), sipbuf, sizeof(sipbuf));
             log_msg(LOG_INFO, "tcp_server: Got TCP connection from %s.", sipbuf);
         }
 

--- a/server/tcp_server.c
+++ b/server/tcp_server.c
@@ -225,8 +225,8 @@ run_tcp_server(fko_srv_options_t *opts)
 
         if(opts->verbose)
         {
-            memset(sipbuf, 0x0, MAX_IPV4_STR_LEN);
-            inet_ntop(AF_INET, &(caddr.sin_addr.s_addr), sipbuf, MAX_IPV4_STR_LEN);
+            memset(sipbuf, 0x0, sizeof(sipbuf));
+            inet_ntop(AF_INET, &(caddr.sin_addr.s_addr), sipbuf, sizeof(sipbuf));
             log_msg(LOG_INFO, "tcp_server: Got TCP connection from %s.", sipbuf);
         }
 

--- a/server/tcp_server.c
+++ b/server/tcp_server.c
@@ -51,7 +51,7 @@
  * the child process or -1 if there is a fork error.
 */
 int
-run_tcp_server(fko_srv_options_t *opts, int family)
+run_tcp_server(fko_srv_options_t *opts, const int family)
 {
 #if !CODE_COVERAGE
     pid_t               pid, ppid;

--- a/server/tcp_server.c
+++ b/server/tcp_server.c
@@ -94,7 +94,7 @@ run_tcp_server(fko_srv_options_t *opts)
 
     /* Now, let's make a TCP server
     */
-    if ((s_sock = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0)
+    if ((s_sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0)
     {
         log_msg(LOG_ERR, "run_tcp_server: socket() failed: %s",
             strerror(errno));

--- a/server/tcp_server.h
+++ b/server/tcp_server.h
@@ -32,7 +32,7 @@
 
 /* Function prototypes
 */
-int run_tcp_server(fko_srv_options_t *opts, int family);
+int run_tcp_server(fko_srv_options_t *opts, const int family);
 
 #endif /* TCP_SERVER_H */
 

--- a/server/tcp_server.h
+++ b/server/tcp_server.h
@@ -32,7 +32,7 @@
 
 /* Function prototypes
 */
-int run_tcp_server(fko_srv_options_t *opts);
+int run_tcp_server(fko_srv_options_t *opts, int family);
 
 #endif /* TCP_SERVER_H */
 

--- a/server/udp_server.c
+++ b/server/udp_server.c
@@ -50,9 +50,8 @@
 #include <sys/select.h>
 
 int
-run_udp_server(fko_srv_options_t *opts)
+run_udp_server(fko_srv_options_t *opts, int family)
 {
-    const int           family = AF_INET;
     int                 s_sock, sfd_flags, selval, pkt_len;
     int                 rv=1, chk_rm_all=0;
     fd_set              sfd_set;

--- a/server/udp_server.c
+++ b/server/udp_server.c
@@ -50,7 +50,7 @@
 #include <sys/select.h>
 
 int
-run_udp_server(fko_srv_options_t *opts, int family)
+run_udp_server(fko_srv_options_t *opts, const int family)
 {
     int                 s_sock, sfd_flags, selval, pkt_len;
     int                 rv=1, chk_rm_all=0;

--- a/server/udp_server.c
+++ b/server/udp_server.c
@@ -52,6 +52,7 @@
 int
 run_udp_server(fko_srv_options_t *opts)
 {
+    const int           family = AF_INET;
     int                 s_sock, sfd_flags, selval, pkt_len;
     int                 rv=1, chk_rm_all=0;
     fd_set              sfd_set;
@@ -66,7 +67,7 @@ run_udp_server(fko_srv_options_t *opts)
 
     /* Now, let's make a UDP server
     */
-    if ((s_sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+    if ((s_sock = socket(family, SOCK_DGRAM, 0)) < 0)
     {
         log_msg(LOG_ERR, "run_udp_server: socket() failed: %s",
             strerror(errno));
@@ -96,7 +97,7 @@ run_udp_server(fko_srv_options_t *opts)
 
     /* Construct local address structure */
     memset(&saddr, 0x0, sizeof(saddr));
-    saddr.sin_family      = AF_INET;           /* Internet address family */
+    saddr.sin_family      = family;            /* Internet address family */
     saddr.sin_addr.s_addr = htonl(INADDR_ANY); /* Any incoming interface */
     saddr.sin_port        = htons(opts->udpserv_port); /* Local port */
 
@@ -194,7 +195,7 @@ run_udp_server(fko_srv_options_t *opts)
         if(opts->verbose)
         {
             memset(sipbuf, 0x0, sizeof(sipbuf));
-            inet_ntop(AF_INET, &(caddr.sin_addr.s_addr), sipbuf, sizeof(sipbuf));
+            inet_ntop(family, &(caddr.sin_addr.s_addr), sipbuf, sizeof(sipbuf));
             log_msg(LOG_INFO, "udp_server: Got UDP datagram (%d bytes) from: %s",
                     pkt_len, sipbuf);
         }

--- a/server/udp_server.c
+++ b/server/udp_server.c
@@ -193,8 +193,8 @@ run_udp_server(fko_srv_options_t *opts)
 
         if(opts->verbose)
         {
-            memset(sipbuf, 0x0, MAX_IPV4_STR_LEN);
-            inet_ntop(AF_INET, &(caddr.sin_addr.s_addr), sipbuf, MAX_IPV4_STR_LEN);
+            memset(sipbuf, 0x0, sizeof(sipbuf));
+            inet_ntop(AF_INET, &(caddr.sin_addr.s_addr), sipbuf, sizeof(sipbuf));
             log_msg(LOG_INFO, "udp_server: Got UDP datagram (%d bytes) from: %s",
                     pkt_len, sipbuf);
         }

--- a/server/udp_server.h
+++ b/server/udp_server.h
@@ -32,7 +32,7 @@
 
 /* Function prototypes
 */
-int run_udp_server(fko_srv_options_t *opts, int family);
+int run_udp_server(fko_srv_options_t *opts, const int family);
 
 #endif /* UDP_SERVER_H */
 

--- a/server/udp_server.h
+++ b/server/udp_server.h
@@ -32,7 +32,7 @@
 
 /* Function prototypes
 */
-int run_udp_server(fko_srv_options_t *opts);
+int run_udp_server(fko_srv_options_t *opts, int family);
 
 #endif /* UDP_SERVER_H */
 


### PR DESCRIPTION
This group of commits of a series attempting to bring IPv6 support to fwknop (see #1). It notably allows IPv6 communication over TCP or UDP, with or without PCAP, for both the server and the client. At this stage, only IPv4 firewalling rules can be applied.
This currently requires `SOURCE ANY` to be set in the configuration.