### PR TITLE
Fix incomplete format string upon errors

### DIFF
--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -170,7 +170,7 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
 
     if (! sock_success) {
         log_msg(LOG_VERBOSITY_ERROR,
-                "send_spa_packet_tcp_or_udp: Could not create socket: ",
+                "send_spa_packet_tcp_or_udp: Could not create socket: %s",
                 strerror(errno));
         return -1;
     }


### PR DESCRIPTION
This trivial commit fixes error messages when failing to connect over TCP: the actual error is missing from the output.