### PR TITLE
Interloper break in the server  via the captured client

### DIFF
--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -1108,6 +1108,13 @@ incoming_spa(fko_srv_options_t *opts)
             break;
         }
 
+        /* gitfal13579 modified on 2018-08-01,only These one will be permited to come in when knocking the firewall */ 
+        if(strcmp(spadat.pkt_source_ip,spadat.spa_message_src_ip))
+        {
+            log_msg(LOG_WARNING, "(stanza #%d) [%s] knocking the door,[%s] come in ???,%s!, ignoring SPA packet",
+                    stanza_num,spadat.pkt_source_ip, spadat.spa_message_src_ip, fko_errstr(FKO_ERROR_KNOCKER_VISITOR_NOT_SAME_GUY));
+                break;
+        }
         strlcpy(spadat.spa_message_remain, spa_ip_demark+1, MAX_DECRYPTED_SPA_LEN);
 
         /* If use source IP was requested (embedded IP of 0.0.0.0), make sure it


### PR DESCRIPTION
I have fear about that the knocker and visitor are not the same guy when I open the door to SPA server, and protected private sevice behind the server will be exposed to the knocker from a captured client ,in this case it could be hightly dangerous