### PR TITLE
Use execvp() instead of execvpe()

### DIFF
--- a/client/http_resolve_host.c
+++ b/client/http_resolve_host.c
@@ -328,8 +328,8 @@ resolve_ip_https(fko_cli_options_t *options)
     struct  url url; /* for validation only */
     char    wget_ssl_cmd[MAX_URL_PATH_LEN] = {0};  /* for verbose logging only */
 
-#if HAVE_EXECVPE
-    char   *wget_argv[MAX_CMDLINE_ARGS]; /* for execvpe() */
+#if HAVE_EXECVP
+    char   *wget_argv[MAX_CMDLINE_ARGS]; /* for execvp() */
     int     wget_argc=0;
     int     pipe_fd[2];
     pid_t   pid=0;
@@ -339,7 +339,7 @@ resolve_ip_https(fko_cli_options_t *options)
     FILE *wget;
 #endif
 
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
     memset(wget_argv, 0x0, sizeof(wget_argv));
 #endif
     memset(&url, 0x0, sizeof(url));
@@ -410,7 +410,7 @@ resolve_ip_https(fko_cli_options_t *options)
     return(1);
 #endif
 
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
     if(strtoargv(wget_ssl_cmd, wget_argv, &wget_argc) != 1)
     {
         log_msg(LOG_VERBOSITY_ERROR, "Error converting wget cmd str to argv");
@@ -434,14 +434,14 @@ resolve_ip_https(fko_cli_options_t *options)
         close(pipe_fd[0]);
         dup2(pipe_fd[1], STDOUT_FILENO);
         dup2(pipe_fd[1], STDERR_FILENO);
-        es = execvpe(wget_argv[0], wget_argv, (char * const *)NULL); /* don't use env */
+        es = execvp(wget_argv[0], wget_argv);
 
         if(es == -1)
             log_msg(LOG_VERBOSITY_ERROR,
-                    "[*] resolve_ip_https(): execvpe() failed: %s",
+                    "[*] resolve_ip_https(): execvp() failed: %s",
                     strerror(errno));
 
-        /* We only make it here if there was a problem with execvpe(),
+        /* We only make it here if there was a problem with execvp(),
          * so exit() here either way
         */
         exit(es);

--- a/configure.ac
+++ b/configure.ac
@@ -389,17 +389,17 @@ AC_FUNC_STAT
 
 AC_CHECK_FUNCS([bzero gettimeofday memmove memset socket strchr strcspn strdup strncasecmp strndup strrchr strspn strnlen stat lstat chmod chown strlcat strlcpy])
 
-dnl Decide whether or not to check for the execvpe() function
+dnl Decide whether or not to check for the execvp() function
 dnl
-use_execvpe=yes
-AC_ARG_ENABLE([execvpe],
-  [AS_HELP_STRING([--disable-execvpe],
-    [Do not check for the execvpe() function for command execution @<:@default is on@:>@])],
-  [use_execvpe=$enableval],
+use_execvp=yes
+AC_ARG_ENABLE([execvp],
+  [AS_HELP_STRING([--disable-execvp],
+    [Do not check for the execvp() function for command execution @<:@default is on@:>@])],
+  [use_execvp=$enableval],
   [])
 
-if test "x$use_execvpe" = "xyes"; then
-    AC_CHECK_FUNCS([execvpe])
+if test "x$use_execvp" = "xyes"; then
+    AC_CHECK_FUNCS([execvp])
 fi
 
 AC_SEARCH_LIBS([socket], [socket])

--- a/server/extcmd.c
+++ b/server/extcmd.c
@@ -128,10 +128,10 @@ _run_extcmd(uid_t uid, gid_t gid, const char *cmd, char *so_buf,
     int     line_ctr = 0, found_str = 0, do_break = 0;
     int     es = 0;
 
-    char   *argv_new[MAX_CMDLINE_ARGS]; /* for validation and/or execvpe() */
+    char   *argv_new[MAX_CMDLINE_ARGS]; /* for validation and/or execvp() */
     int     argc_new=0;
 
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
     int     pipe_fd[2];
 #endif
 
@@ -143,7 +143,7 @@ _run_extcmd(uid_t uid, gid_t gid, const char *cmd, char *so_buf,
 
     *pid_status = 0;
 
-    /* Even without execvpe() we examine the command for basic validity
+    /* Even without execvp() we examine the command for basic validity
      * in term of number of args
     */
     memset(argv_new, 0x0, sizeof(argv_new));
@@ -155,16 +155,16 @@ _run_extcmd(uid_t uid, gid_t gid, const char *cmd, char *so_buf,
         return EXTCMD_ARGV_ERROR;
     }
 
-#if !HAVE_EXECVPE
-    /* if we are not using execvpe() then free up argv_new unconditionally
+#if !HAVE_EXECVP
+    /* if we are not using execvp() then free up argv_new unconditionally
      * since was used only for validation
     */
     free_argv(argv_new, &argc_new);
 #endif
 
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
     if(opts->verbose > 1)
-        log_msg(LOG_INFO, "run_extcmd() (with execvpe()): running CMD: %s", cmd);
+        log_msg(LOG_INFO, "run_extcmd() (with execvp()): running CMD: %s", cmd);
 
     if(so_buf != NULL || substr_search != NULL)
     {
@@ -204,12 +204,12 @@ _run_extcmd(uid_t uid, gid_t gid, const char *cmd, char *so_buf,
 
         /* don't use env
         */
-        es = execvpe(argv_new[0], argv_new, (char * const *)NULL);
+        es = execvp(argv_new[0], argv_new);
 
         if(es == -1)
-            log_msg(LOG_ERR, "run_extcmd(): execvpe() failed: %s", strerror(errno));
+            log_msg(LOG_ERR, "run_extcmd(): execvp() failed: %s", strerror(errno));
 
-        /* We only make it here if there was a problem with execvpe(),
+        /* We only make it here if there was a problem with execvp(),
          * so exit() here either way to not leave another fwknopd process
          * running after fork().
         */
@@ -265,7 +265,7 @@ _run_extcmd(uid_t uid, gid_t gid, const char *cmd, char *so_buf,
 #else
 
     if(opts->verbose > 1)
-        log_msg(LOG_INFO, "run_extcmd() (without execvpe()): running CMD: %s", cmd);
+        log_msg(LOG_INFO, "run_extcmd() (without execvp()): running CMD: %s", cmd);
 
     if(so_buf == NULL && substr_search == NULL)
     {
@@ -586,10 +586,10 @@ int _run_extcmd_write(const char *cmd, const char *cmd_write, int *pid_status,
         const fko_srv_options_t * const opts)
 {
     int     retval = EXTCMD_SUCCESS_ALL_OUTPUT;
-    char   *argv_new[MAX_CMDLINE_ARGS]; /* for validation and/or execvpe() */
+    char   *argv_new[MAX_CMDLINE_ARGS]; /* for validation and/or execvp() */
     int     argc_new=0;
 
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
     int     pipe_fd[2];
     pid_t   pid=0;
 #else
@@ -602,7 +602,7 @@ int _run_extcmd_write(const char *cmd, const char *cmd_write, int *pid_status,
 
     *pid_status = 0;
 
-    /* Even without execvpe() we examine the command for basic validity
+    /* Even without execvp() we examine the command for basic validity
      * in term of number of args
     */
     memset(argv_new, 0x0, sizeof(argv_new));
@@ -614,16 +614,16 @@ int _run_extcmd_write(const char *cmd, const char *cmd_write, int *pid_status,
         return EXTCMD_ARGV_ERROR;
     }
 
-#if !HAVE_EXECVPE
-    /* if we are not using execvpe() then free up argv_new unconditionally
+#if !HAVE_EXECVP
+    /* if we are not using execvp() then free up argv_new unconditionally
      * since was used only for validation
     */
     free_argv(argv_new, &argc_new);
 #endif
 
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
     if(opts->verbose > 1)
-        log_msg(LOG_INFO, "run_extcmd_write() (with execvpe()): running CMD: %s | %s",
+        log_msg(LOG_INFO, "run_extcmd_write() (with execvp()): running CMD: %s | %s",
                 cmd_write, cmd);
 
     if(pipe(pipe_fd) < 0)
@@ -644,7 +644,7 @@ int _run_extcmd_write(const char *cmd, const char *cmd_write, int *pid_status,
 
         /* don't use env
         */
-        execvpe(argv_new[0], argv_new, (char * const *)NULL);
+        execvp(argv_new[0], argv_new);
     }
     else if(pid == -1)
     {
@@ -664,7 +664,7 @@ int _run_extcmd_write(const char *cmd, const char *cmd_write, int *pid_status,
 
 #else
     if(opts->verbose > 1)
-        log_msg(LOG_INFO, "run_extcmd_write() (without execvpe()): running CMD: %s | %s",
+        log_msg(LOG_INFO, "run_extcmd_write() (without execvp()): running CMD: %s | %s",
                 cmd_write, cmd);
 
     if ((fd = popen(cmd, "w")) == NULL)

--- a/server/fw_util_firewalld.h
+++ b/server/fw_util_firewalld.h
@@ -35,8 +35,8 @@
 #define FIREWD_CMD_FAIL_STR   "COMMAND_FAILED" /* returned by firewall-cmd */
 #define FIREWD_CMD_PREFIX     "--direct --passthrough ipv4"
 
-#if HAVE_EXECVPE
-  #define SH_REDIR "" /* the shell is not used when execvpe() is available */
+#if HAVE_EXECVP
+  #define SH_REDIR "" /* the shell is not used when execvp() is available */
 #else
   #define SH_REDIR " 2>&1"
 #endif

--- a/server/fw_util_iptables.h
+++ b/server/fw_util_iptables.h
@@ -32,8 +32,8 @@
 
 #define SNAT_TARGET_BUFSIZE         64
 
-#if HAVE_EXECVPE
-  #define SH_REDIR "" /* the shell is not used when execvpe() is available */
+#if HAVE_EXECVP
+  #define SH_REDIR "" /* the shell is not used when execvp() is available */
 #else
   #define SH_REDIR " 2>&1"
 #endif

--- a/server/fw_util_pf.h
+++ b/server/fw_util_pf.h
@@ -33,8 +33,8 @@
 #define MAX_PF_ANCHOR_SEARCH_LEN    (MAX_PF_ANCHOR_LEN+11)   /* room for 'anchor "' string */
 #define MAX_PF_NEW_RULE_LEN         140
 
-#if HAVE_EXECVPE
-  #define SH_REDIR "" /* the shell is not used when execvpe() is available */
+#if HAVE_EXECVP
+  #define SH_REDIR "" /* the shell is not used when execvp() is available */
 #else
   #define SH_REDIR " 2>&1"
 #endif
@@ -43,7 +43,7 @@
 */
 #define PF_ADD_RULE_ARGS              "pass in quick proto %u from %s to %s port %u keep state label " EXPIRE_COMMENT_PREFIX "%u"
 #define PF_WRITE_ANCHOR_RULES_ARGS    "-a %s -f -"
-#if HAVE_EXECVPE
+#if HAVE_EXECVP
   #define PF_LIST_ANCHOR_RULES_ARGS   "-a %s -s rules"
 #else
   #define PF_LIST_ANCHOR_RULES_ARGS   "-a %s -s rules 2> /dev/null"

--- a/test/test-fwknop.pl
+++ b/test/test-fwknop.pl
@@ -2103,14 +2103,14 @@ sub configure_args_restore_orig() {
     return $rv;
 }
 
-sub configure_args_disable_execvpe() {
+sub configure_args_disable_execvp() {
     my $rv = 1;
 
     my $curr_pwd = cwd() or die $!;
 
     chdir '..' or die $!;
 
-    unless (&config_recompile('./extras/apparmor/configure_args.sh --disable-execvpe')) {
+    unless (&config_recompile('./extras/apparmor/configure_args.sh --disable-execvp')) {
         &write_test_file("[-] configure/recompile failure.\n",
             "test/$curr_test_file");
         chdir $curr_pwd or die $!;

--- a/test/tests/configure_args.pl
+++ b/test/tests/configure_args.pl
@@ -46,12 +46,12 @@
         'fw_rule_created' => $REQUIRE_NO_NEW_RULE,
     },
 
-    ### disable execvpe() usage
+    ### disable execvp() usage
     {
         'category' => 'configure args',
         'subcategory' => 'compile',
-        'detail'   => '--disable-execvpe check',
-        'function' => \&configure_args_disable_execvpe,
+        'detail'   => '--disable-execvp check',
+        'function' => \&configure_args_disable_execvp,
     },
     {
         'category' => 'configure args',
@@ -64,7 +64,7 @@
         'fw_rule_created' => $NEW_RULE_REQUIRED,
         'fw_rule_removed' => $NEW_RULE_REMOVED,
         'key_file' => $cf{'rc_hmac_b64_key'},
-        'server_positive_output_matches' => [qr/without execvpe/],
+        'server_positive_output_matches' => [qr/without execvp/],
     },
     {
         'category' => 'configure args',
@@ -77,7 +77,7 @@
         'fw_rule_created' => $NEW_RULE_REQUIRED,
         'fw_rule_removed' => $NEW_RULE_REMOVED,
         'key_file' => $cf{'rc_hmac_b64_key'},
-        'server_positive_output_matches' => [qr/without execvpe/],
+        'server_positive_output_matches' => [qr/without execvp/],
         'client_cycles_per_server_instance' => 3,
     },
 
@@ -92,7 +92,7 @@
         'fwknopd_cmdline'  => "$fwknopdCmd -c $cf{'def'} -a $cf{'hmac_cmd_access'} " .
             "-d $default_digest_file -p $default_pid_file $intf_str",
         'fw_rule_created' => $REQUIRE_NO_NEW_RULE,
-        'server_positive_output_matches' => [qr/without execvpe/],
+        'server_positive_output_matches' => [qr/without execvp/],
     },
 
     ### restore original ./configure args to be prepared to run


### PR DESCRIPTION
execvp() is (usually) equivalent to execvpe(), without enforcing any
change to the environment. However, unlike execvp(), execvpe() is not
standardized by POSIX, and may therefore not be available nor detected
when configuring the project (like on NetBSD).

No place could be found in fwknop to be using execvpe() and changing the
environment. Therefore it seems only logical (and safer) to use execvp()
instead.

This also updates the tests to reflect this change.