### PR TITLE
Seed random() at least a bit before using random()

### DIFF
--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -250,6 +250,7 @@ send_spa_packet_tcp_raw(const char *spa_data, const int sd_len,
     /* Total size is header plus payload */
     iph->tot_len    = hdrlen + sd_len;
     /* The value here does not matter */
+    srandom(time(NULL) ^ getuid() ^ (getgid() << 16) ^ getpid());
     iph->id         = random() & 0xffff;
     iph->frag_off   = 0;
     iph->ttl        = RAW_SPA_TTL;
@@ -363,6 +364,7 @@ send_spa_packet_udp_raw(const char *spa_data, const int sd_len,
     /* Total size is header plus payload */
     iph->tot_len    = hdrlen + sd_len;
     /* The value here does not matter */
+    srandom(time(NULL) ^ getuid() ^ (getgid() << 16) ^ getpid());
     iph->id         = random() & 0xffff;
     iph->frag_off   = 0;
     iph->ttl        = RAW_SPA_TTL;
@@ -462,6 +464,7 @@ send_spa_packet_icmp(const char *spa_data, const int sd_len,
     /* Total size is header plus payload */
     iph->tot_len    = hdrlen + sd_len;
     /* The value here does not matter */
+    srandom(time(NULL) ^ getuid() ^ (getgid() << 16) ^ getpid());
     iph->id         = random() & 0xffff;
     iph->frag_off   = 0;
     iph->ttl        = RAW_SPA_TTL;


### PR DESCRIPTION
In fwknop, the values generated using random() are only used for the ID
field of raw IP packets. As indicated in the corresponding comments,
this value does not really matter, and it does not really have to be
random at all.

However, it should not hurt to initialize the entropy pool before
generating random values. arc4random() would be a better choice, but it
is not portable across the range of systems currently supported by
fwknop.