### PR TITLE
Fix two erroneous calls to strlcat()

### DIFF
--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -698,8 +698,7 @@ set_access_buf(fko_ctx_t ctx, fko_cli_options_t *options, char *access_buf)
 
             /* This adds in the protocol + '/' char
             */
-            strlcat(access_buf, options->access_str,
-                    strlen(access_buf) + (ndx - options->access_str) + 2);
+            strlcat(access_buf, options->access_str, MAX_LINE_LEN);
 
             if (strchr(ndx+1, '/') != NULL)
             {
@@ -711,8 +710,7 @@ set_access_buf(fko_ctx_t ctx, fko_cli_options_t *options, char *access_buf)
             /* Now add the NAT port
             */
             snprintf(tmp_nat_port, MAX_PORT_STR_LEN+1, "%d", nat_port);
-            strlcat(access_buf, tmp_nat_port,
-                    strlen(access_buf)+MAX_PORT_STR_LEN+1);
+            strlcat(access_buf, tmp_nat_port, MAX_LINE_LEN);
         }
         else
         {


### PR DESCRIPTION
strlcat() needs to be informed about the actual size of the buffer. Two
calls simply used the size expected, thus potentially allowing
stack-based buffer overflows.

There is no direct security impact in this case, since the code affected
is on the client side, and the input comes from configuration
information.