### PR TITLE
khorben/coverity/1355235 TOCTOU

### DIFF
--- a/client/config_init.c
+++ b/client/config_init.c
@@ -696,7 +696,7 @@ set_rc_file(char *rcfile, fko_cli_options_t *options)
      * client consumes a proper rc file with strict permissions set (thanks
      * to Fernando Arnaboldi from IOActive for pointing this out).
     */
-    if(verify_file_perms_ownership(rcfile) != 1)
+    if(verify_file_perms_ownership(rcfile, -1) != 1)
         exit(EXIT_FAILURE);
 
     return;

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -893,12 +893,15 @@ show_last_command(const char * const args_save_file)
     char args_str[MAX_LINE_LEN] = {0};
     FILE *args_file_ptr = NULL;
 
-    if(verify_file_perms_ownership(args_save_file) != 1)
-        return 0;
-
     if ((args_file_ptr = fopen(args_save_file, "r")) == NULL) {
         log_msg(LOG_VERBOSITY_ERROR, "Could not open args file: %s",
             args_save_file);
+        return 0;
+    }
+
+    if(verify_file_perms_ownership(args_save_file, fileno(args_file_ptr)) != 1)
+    {
+        fclose(args_file_ptr);
         return 0;
     }
 
@@ -928,13 +931,15 @@ run_last_args(fko_cli_options_t *options, const char * const args_save_file)
 
     memset(argv_new, 0x0, sizeof(argv_new));
 
-    if(verify_file_perms_ownership(args_save_file) != 1)
-        return 0;
-
     if ((args_file_ptr = fopen(args_save_file, "r")) == NULL)
     {
         log_msg(LOG_VERBOSITY_ERROR, "Could not open args file: %s",
                 args_save_file);
+        return 0;
+    }
+    if(verify_file_perms_ownership(args_save_file, fileno(args_file_ptr)) != 1)
+    {
+        fclose(args_file_ptr);
         return 0;
     }
     if ((fgets(args_str, MAX_LINE_LEN, args_file_ptr)) != NULL)

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -899,7 +899,11 @@ show_last_command(const char * const args_save_file)
         return 0;
     }
 
+#if HAVE_FILENO
     if(verify_file_perms_ownership(args_save_file, fileno(args_file_ptr)) != 1)
+#else
+    if(verify_file_perms_ownership(args_save_file, -1) != 1)
+#endif
     {
         fclose(args_file_ptr);
         return 0;
@@ -937,7 +941,11 @@ run_last_args(fko_cli_options_t *options, const char * const args_save_file)
                 args_save_file);
         return 0;
     }
+#if HAVE_FILENO
     if(verify_file_perms_ownership(args_save_file, fileno(args_file_ptr)) != 1)
+#else
+    if(verify_file_perms_ownership(args_save_file, -1) != 1)
+#endif
     {
         fclose(args_file_ptr);
         return 0;

--- a/client/utils.c
+++ b/client/utils.c
@@ -56,17 +56,17 @@ static fko_protocol_t fko_protocol_array[] =
 };
 
 int
-verify_file_perms_ownership(const char *file)
+verify_file_perms_ownership(const char *file, int fd)
 {
     int res = 1;
 
-#if HAVE_STAT
+#if HAVE_FSTAT && HAVE_STAT
     struct stat st;
 
     /* Every file that the fwknop client deals with should be owned
      * by the user and permissions set to 600 (user read/write)
     */
-    if((stat(file, &st)) == 0)
+    if((fd >= 0 && fstat(fd, &st) == 0) || stat(file, &st) == 0)
     {
         /* Make sure it is a regular file
         */

--- a/client/utils.h
+++ b/client/utils.h
@@ -52,7 +52,7 @@
 
 /* Prototypes
 */
-int     verify_file_perms_ownership(const char *file);
+int     verify_file_perms_ownership(const char *file, int fd);
 int     resolve_dst_addr(const char *dns_str, struct addrinfo *hints,
             char *ip_str, size_t ip_bufsize, fko_cli_options_t *opts);
 short   proto_inttostr(int proto, char *proto_str, size_t proto_size);

--- a/configure.ac
+++ b/configure.ac
@@ -400,7 +400,7 @@ AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_FUNC_STAT
 
-AC_CHECK_FUNCS([bzero gettimeofday memmove memset socket strchr strcspn strdup strncasecmp strndup strrchr strspn strnlen stat lstat chmod chown strlcat strlcpy])
+AC_CHECK_FUNCS([bzero fileno gettimeofday memmove memset socket strchr strcspn strdup strncasecmp strndup strrchr strspn strnlen fstat stat lstat chmod chown strlcat strlcpy])
 
 dnl Decide whether or not to check for the execvp() function
 dnl

--- a/server/access.c
+++ b/server/access.c
@@ -2343,7 +2343,6 @@ int
 include_keys_file(acc_stanza_t *curr_acc, const char *access_filename, fko_srv_options_t *opts)
 {
     FILE           *file_ptr;
-    struct stat     st;
     unsigned int    num_lines = 0;
 
     char            access_line_buf[MAX_LINE_LEN] = {0};
@@ -2352,13 +2351,6 @@ include_keys_file(acc_stanza_t *curr_acc, const char *access_filename, fko_srv_o
     char           *ndx;
 
     log_msg(LOG_INFO, "Including key file: '%s'", access_filename);
-    if(stat(access_filename, &st) != 0)
-    {
-        log_msg(LOG_ERR, "[*] Access file: '%s' was not found.",
-            access_filename);
-
-        return EXIT_FAILURE;
-    }
 
     if ((file_ptr = fopen(access_filename, "r")) == NULL)
     {

--- a/server/access.c
+++ b/server/access.c
@@ -1508,7 +1508,11 @@ parse_access_file(fko_srv_options_t *opts, char *access_filename, int *depth)
         return EXIT_FAILURE;
     }
 
+#if HAVE_FILENO
     if(verify_file_perms_ownership(access_filename, fileno(file_ptr)) != 1)
+#else
+    if(verify_file_perms_ownership(access_filename, -1) != 1)
+#endif
     {
         fclose(file_ptr);
         return EXIT_FAILURE;

--- a/server/config_init.c
+++ b/server/config_init.c
@@ -303,7 +303,11 @@ parse_config_file(fko_srv_options_t *opts, const char *config_file)
         clean_exit(opts, NO_FW_CLEANUP, EXIT_FAILURE);
     }
 
+#if HAVE_FILENO
     if(verify_file_perms_ownership(config_file, fileno(cfile_ptr)) != 1)
+#else
+    if(verify_file_perms_ownership(config_file, -1) != 1)
+#endif
     {
         fclose(cfile_ptr);
         clean_exit(opts, NO_FW_CLEANUP, EXIT_FAILURE);

--- a/server/config_init.c
+++ b/server/config_init.c
@@ -291,20 +291,6 @@ parse_config_file(fko_srv_options_t *opts, const char *config_file)
     char            tmp1[MAX_LINE_LEN] = {0};
     char            tmp2[MAX_LINE_LEN] = {0};
 
-    struct stat     st;
-
-    /* Make sure the config file exists.
-    */
-    if(stat(config_file, &st) != 0)
-    {
-        log_msg(LOG_ERR, "[*] Config file: '%s' was not found.",
-            config_file);
-        clean_exit(opts, NO_FW_CLEANUP, EXIT_FAILURE);
-    }
-
-    if(verify_file_perms_ownership(config_file) != 1)
-        clean_exit(opts, NO_FW_CLEANUP, EXIT_FAILURE);
-
     /* See the comment in the parse_access_file() function regarding security
      * here relative to a TOCTOU bug flagged by Coverity.
     */
@@ -314,6 +300,12 @@ parse_config_file(fko_srv_options_t *opts, const char *config_file)
             config_file);
         perror(NULL);
 
+        clean_exit(opts, NO_FW_CLEANUP, EXIT_FAILURE);
+    }
+
+    if(verify_file_perms_ownership(config_file, fileno(cfile_ptr)) != 1)
+    {
+        fclose(cfile_ptr);
         clean_exit(opts, NO_FW_CLEANUP, EXIT_FAILURE);
     }
 

--- a/server/fwknopd.c
+++ b/server/fwknopd.c
@@ -1015,18 +1015,19 @@ get_running_pid(const fko_srv_options_t *opts)
     pid_t   rpid            = 0;
 
 
-    if(verify_file_perms_ownership(opts->config[CONF_FWKNOP_PID_FILE]) != 1)
-    {
-        fprintf(stderr, "verify_file_perms_ownership() error\n");
-        return(rpid);
-    }
-
     op_fd = open(opts->config[CONF_FWKNOP_PID_FILE], O_RDONLY);
 
     if(op_fd == -1)
     {
         if((opts->foreground != 0) && (opts->verbose != 0))
             perror("Error trying to open PID file: ");
+        return(rpid);
+    }
+
+    if(verify_file_perms_ownership(opts->config[CONF_FWKNOP_PID_FILE], op_fd) != 1)
+    {
+        fprintf(stderr, "verify_file_perms_ownership() error\n");
+        close(op_fd);
         return(rpid);
     }
 

--- a/server/replay_cache.c
+++ b/server/replay_cache.c
@@ -274,7 +274,11 @@ replay_file_cache_init(fko_srv_options_t *opts)
         return(-1);
     }
 
+#if HAVE_FILENO
     if(verify_file_perms_ownership(opts->config[CONF_DIGEST_FILE], fileno(digest_file_ptr)) != 1)
+#else
+    if(verify_file_perms_ownership(opts->config[CONF_DIGEST_FILE], -1) != 1)
+#endif
     {
         fclose(digest_file_ptr);
         return(-1);

--- a/server/replay_cache.c
+++ b/server/replay_cache.c
@@ -265,15 +265,18 @@ replay_file_cache_init(fko_srv_options_t *opts)
         }
     }
 
-    if(verify_file_perms_ownership(opts->config[CONF_DIGEST_FILE]) != 1)
-        return(-1);
-
     /* File exists, and we have access - create in-memory digest cache
     */
     if ((digest_file_ptr = fopen(opts->config[CONF_DIGEST_FILE], "r")) == NULL)
     {
         log_msg(LOG_WARNING, "Could not open digest cache: %s: %s",
             opts->config[CONF_DIGEST_FILE], strerror(errno));
+        return(-1);
+    }
+
+    if(verify_file_perms_ownership(opts->config[CONF_DIGEST_FILE], fileno(digest_file_ptr)) != 1)
+    {
+        fclose(digest_file_ptr);
         return(-1);
     }
 

--- a/server/utils.c
+++ b/server/utils.c
@@ -111,13 +111,13 @@ is_valid_file(const char *path)
 int
 verify_file_perms_ownership(const char *file, int fd)
 {
-#if HAVE_FSTAT
+#if HAVE_FSTAT && HAVE_STAT
     struct stat st;
 
     /* Every file that fwknopd deals with should be owned
      * by the user and permissions set to 600 (user read/write)
     */
-    if(fstat(fd, &st) == 0)
+    if((fd >= 0 && fstat(fd, &st) == 0) || stat(file, &st) == 0)
     {
         /* Make sure it is a regular file
         */

--- a/server/utils.c
+++ b/server/utils.c
@@ -109,15 +109,15 @@ is_valid_file(const char *path)
 }
 
 int
-verify_file_perms_ownership(const char *file)
+verify_file_perms_ownership(const char *file, int fd)
 {
-#if HAVE_STAT
+#if HAVE_FSTAT
     struct stat st;
 
     /* Every file that fwknopd deals with should be owned
      * by the user and permissions set to 600 (user read/write)
     */
-    if((stat(file, &st)) == 0)
+    if(fstat(fd, &st) == 0)
     {
         /* Make sure it is a regular file
         */

--- a/server/utils.h
+++ b/server/utils.h
@@ -63,7 +63,7 @@ char* dump_ctx(fko_ctx_t ctx);
 int   is_valid_dir(const char *path);
 int   is_valid_exe(const char *path);
 int   is_valid_file(const char *path);
-int   verify_file_perms_ownership(const char *file);
+int   verify_file_perms_ownership(const char *file, int fd);
 void  truncate_partial_line(char *str);
 int   is_digits(const char * const str);
 


### PR DESCRIPTION
These changes leverage fstat() to avoid TOCTOU conditions. This also requires fileno() when using fopen(). Judging from the existing code, fileno() may not be available on every platform (like Windows). In this case the fallback code is equivalent to the previous one with the flaw.

Reported in Coverity as issue 1355235.