### PR TITLE
Restart fwknop-server on failure

### DIFF
--- a/extras/systemd/fwknopd.service
+++ b/extras/systemd/fwknopd.service
@@ -7,7 +7,7 @@ Type=forking
 PIDFile=/run/fwknop/fwknopd.pid
 ExecStart=/usr/sbin/fwknopd
 ExecReload=/bin/kill -HUP $MAINPID
-Restart=onfailure
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/extras/systemd/fwknopd.service
+++ b/extras/systemd/fwknopd.service
@@ -7,6 +7,7 @@ Type=forking
 PIDFile=/run/fwknop/fwknopd.pid
 ExecStart=/usr/sbin/fwknopd
 ExecReload=/bin/kill -HUP $MAINPID
+Restart=onfailure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Right now, when network interfaces go down and then back up (e.g. undocking and re-docking a laptop), fwknop-server dies and can no longer be used to open the firewall.

This causes the daemon to restart when it fails for any reason other than normal shutdowns/restarts.