### PR TITLE
add -S support for tcp/udp

### DIFF
--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -88,6 +88,7 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
     int     sock=-1, sock_success=0, res=0, error;
     struct  addrinfo *result=NULL, *rp, hints;
     char    port_str[MAX_PORT_STR_LEN+1] = {0};
+    struct sockaddr_in saddr;
 
     if (options->test)
     {
@@ -150,6 +151,25 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
                 rp->ai_protocol);
         if (sock < 0)
             continue;
+
+        if(options->spa_src_port != 0)
+        {
+            if(options->spa_src_port < 0 || options->spa_src_port > MAX_PORT)
+            {
+                log_msg(LOG_VERBOSITY_ERROR, "could not set source port: invalid port specified");
+                return -1;
+            }
+            memset(&saddr, 0, sizeof(saddr));
+            saddr.sin_family = AF_INET;
+            saddr.sin_port = htons(options->spa_src_port);
+            saddr.sin_addr.s_addr = INADDR_ANY;
+            if (bind(sock,(const struct sockaddr *)&saddr,sizeof(saddr)))
+            {
+                log_msg(LOG_VERBOSITY_ERROR, "could not set source port: bind failed, do you need to be root?");
+                return -1;
+            }
+
+        }
 
         if ((error = (connect(sock, rp->ai_addr, rp->ai_addrlen) != -1)))
         {
@@ -250,7 +270,6 @@ send_spa_packet_tcp_raw(const char *spa_data, const int sd_len,
     /* Total size is header plus payload */
     iph->tot_len    = hdrlen + sd_len;
     /* The value here does not matter */
-    srandom(time(NULL) ^ getuid() ^ (getgid() << 16) ^ getpid());
     iph->id         = random() & 0xffff;
     iph->frag_off   = 0;
     iph->ttl        = RAW_SPA_TTL;
@@ -364,7 +383,6 @@ send_spa_packet_udp_raw(const char *spa_data, const int sd_len,
     /* Total size is header plus payload */
     iph->tot_len    = hdrlen + sd_len;
     /* The value here does not matter */
-    srandom(time(NULL) ^ getuid() ^ (getgid() << 16) ^ getpid());
     iph->id         = random() & 0xffff;
     iph->frag_off   = 0;
     iph->ttl        = RAW_SPA_TTL;
@@ -464,7 +482,6 @@ send_spa_packet_icmp(const char *spa_data, const int sd_len,
     /* Total size is header plus payload */
     iph->tot_len    = hdrlen + sd_len;
     /* The value here does not matter */
-    srandom(time(NULL) ^ getuid() ^ (getgid() << 16) ^ getpid());
     iph->id         = random() & 0xffff;
     iph->frag_off   = 0;
     iph->ttl        = RAW_SPA_TTL;
@@ -549,7 +566,7 @@ send_spa_packet_http(const char *spa_data, const int sd_len,
     if(options->http_proxy[0] == 0x0)
     {
         snprintf(http_buf, HTTP_MAX_REQUEST_LEN,
-            "GET /%s HTTP/1.1\r\nUser-Agent: %s\r\nAccept: */*\r\n"
+            "GET /%s HTTP/1.0\r\nUser-Agent: %s\r\nAccept: */*\r\n"
             "Host: %s\r\nConnection: close\r\n\r\n",
             spa_data_copy,
             options->http_user_agent,
@@ -590,7 +607,7 @@ send_spa_packet_http(const char *spa_data, const int sd_len,
             options->spa_dst_port = proxy_port;
 
         snprintf(http_buf, HTTP_MAX_REQUEST_LEN,
-            "GET http://%s/%s HTTP/1.1\r\nUser-Agent: %s\r\nAccept: */*\r\n"
+            "GET http://%s/%s HTTP/1.0\r\nUser-Agent: %s\r\nAccept: */*\r\n"
             "Host: %s\r\nConnection: close\r\n\r\n",
             options->spa_server_str,
             spa_data_copy,

--- a/client/spa_comm.c
+++ b/client/spa_comm.c
@@ -88,7 +88,8 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
     int     sock=-1, sock_success=0, res=0, error;
     struct  addrinfo *result=NULL, *rp, hints;
     char    port_str[MAX_PORT_STR_LEN+1] = {0};
-
+    struct sockaddr_in saddr;
+    
     if (options->test)
     {
         log_msg(LOG_VERBOSITY_NORMAL,
@@ -150,6 +151,24 @@ send_spa_packet_tcp_or_udp(const char *spa_data, const int sd_len,
                 rp->ai_protocol);
         if (sock < 0)
             continue;
+
+        if(options->spa_src_port != 0)
+        {
+            if(options->spa_src_port < 0 || options->spa_src_port > MAX_PORT)
+            {
+                log_msg(LOG_VERBOSITY_ERROR, "could not set source port: invalid port specified");
+                return -1;
+            }
+            memset(&saddr, 0, sizeof(saddr));
+            saddr.sin_family = AF_INET;
+            saddr.sin_port = htons(options->spa_src_port);
+            saddr.sin_addr.s_addr = INADDR_ANY;
+            if (bind(sock,(const struct sockaddr *)&saddr,sizeof(saddr)))
+            {
+                log_msg(LOG_VERBOSITY_ERROR, "could not set source port: bind failed, do you need to be root?");
+                return -1;
+            }
+        }
 
         if ((error = (connect(sock, rp->ai_addr, rp->ai_addrlen) != -1)))
         {


### PR DESCRIPTION
The previous version doesn't allow specifying a source port for regular TCP and UDP packets. I originally started working from a downloaded copy leading to some deletions in the first commit I made then reverted that commit and committed a new version which only adds support for specifying a source port. I think this is especially important because verbose mode will indicate -S works for regular tcp and udp packets when it actually doesn't without this change.