### PR TITLE
Fix compilation with -fno-common (the default in gcc-10+)

### DIFF
--- a/client/log_msg.h
+++ b/client/log_msg.h
@@ -29,7 +29,7 @@
 #ifndef LOG_MSG_H
 #define LOG_MSG_H
 
-enum
+typedef enum
 {
     LOG_FIRST_VERBOSITY = 0,
     LOG_VERBOSITY_ERROR = 0,    /*!< Constant to define a ERROR message */


### PR DESCRIPTION
Tested with gcc-8 and gcc-9 with CFLAGS="-fno-common" using:

./configure --prefix=/usr --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --docdir=/usr/share/doc/fwknop-2.6.10 --htmldir=/usr/share/doc/fwknop-2.6.10/html --with-sysroot=/ --libdir=/usr/lib64 --localstatedir=/run --enable-client --enable-file-cache --disable-nfq-capture --enable-server --disable-udp-server --without-gpgme --with-iptables=/sbin/iptables

It is possible that other fwknop configure-time options would trigger
additional -fno-common errors that I have not seen yet.

Closes: https://github.com/mrash/fwknop/issues/305
Signed-off-by: Hank Leininger <hlein@korelogic.com>