### PR TITLE
Add missing "Wants" directive in systemd unit file

### DIFF
--- a/extras/systemd/fwknopd.service
+++ b/extras/systemd/fwknopd.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Firewall Knock Operator Daemon
+Wants=network-online.target
 After=network-online.target
 
 [Service]


### PR DESCRIPTION
Per the systemd documentation (https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/#cutthecraphowdoimakesurethatmyservicestartsafterthenetworkisreallyonline), both Wants and After are required when
using the network-online.target.

Originally reported on the Debian bug tracker: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=949323