### PR TITLE
Drop the unnecessary PIDFile line

### DIFF
--- a/extras/systemd/fwknopd.service
+++ b/extras/systemd/fwknopd.service
@@ -4,7 +4,6 @@ After=network-online.target
 
 [Service]
 Type=forking
-PIDFile=/run/fwknop/fwknopd.pid
 ExecStart=/usr/sbin/fwknopd
 ExecReload=/bin/kill -HUP $MAINPID
 


### PR DESCRIPTION
This prevents systemd from realizing that `fwknopd` has started properly and ends up timing out and restarting it again. This is probably due to a race condition between systemd checking for the PID file in `/run/fwknop/fwknopd.pid` and `fwknopd` actually writing to that file.

```
fwknopd[2023792]: Starting fwknopd
systemd[1]: fwknop-server.service: New main PID 202379 does not exist or is a zombie.
fwknopd[2023792]: Added jump rule from chain: INPUT to chain: FWKNOP_INPUT
fwknopd[2023792]: iptables 'comment' match is available
fwknopd[2023792]: Sniffing interface: enp0s25
fwknopd[2023792]: PCAP filter is: 'udp port 62201'
fwknopd[2023792]: Starting fwknopd main event loop.
systemd[1]: fwknop-server.service: start operation timed out. Terminating.
fwknopd[2023792]: Gracefully leaving the fwknopd event loop.
fwknopd[2023792]: Got SIGTERM. Exiting...
fwknopd[2023792]: Shutting Down fwknopd.
systemd[1]: fwknop-server.service: Failed with result 'timeout'.
systemd[1]: Failed to start Firewall Knock Operator Daemon.
systemd[1]: fwknop-server.service: Scheduled restart job, restart counter is at 1.
systemd[1]: Stopped Firewall Knock Operator Daemon.
```
Removing the `PIDFile` line is how I fixed this problem in the Debian package for fwknop-server.