### PR TITLE
Fix compilation with GCC's -fno-common flag (fixes #305)

### DIFF
--- a/client/log_msg.h
+++ b/client/log_msg.h
@@ -38,7 +38,7 @@ enum
     LOG_VERBOSITY_INFO,         /*!< Constant to define a INFO message */
     LOG_VERBOSITY_DEBUG,        /*!< Constant to define a DEBUG message */
     LOG_LAST_VERBOSITY
-} log_level_t;
+};
 
 #define LOG_DEFAULT_VERBOSITY   LOG_VERBOSITY_NORMAL    /*!< Default verbosity to use */
 


### PR DESCRIPTION
This is the patch I [applied to the Debian package](https://salsa.debian.org/debian/fwknop/-/blob/master/debian/patches/005_gcc10.patch) to make fwknop compile under GCC 10.

It is originally from https://github.com/Jakuje/fwknop/commit/a87325b0816a79329cf0b4d4f9ebf247ead117db.