### PR TITLE
Fix multiple definitions of log_level_t

### DIFF
--- a/client/log_msg.h
+++ b/client/log_msg.h
@@ -29,7 +29,7 @@
 #ifndef LOG_MSG_H
 #define LOG_MSG_H
 
-enum
+typedef enum
 {
     LOG_FIRST_VERBOSITY = 0,
     LOG_VERBOSITY_ERROR = 0,    /*!< Constant to define a ERROR message */


### PR DESCRIPTION
When compiling with -fno-common linking fails,
because log_level_t is a global variable instead of a typedef
as was probably intended given the name.

gcc 10 changed the default from -fcommon to -fno-common,
but this change is enough for gcc 10.2.0 to compile on my machine,
without having to set -fcommon manually.