### PR TITLE
fix: remove obsolete function from libfko

### DIFF
--- a/doc/libfko.texi
+++ b/doc/libfko.texi
@@ -4,9 +4,6 @@
 @include version.texi
 @settitle Firewall Knock Operator Library - libfko
 @c @setchapternewpage odd
-@ifnothtml
-@setcontentsaftertitlepage
-@end ifnothtml
 @finalout
 @c Unify some of the indices.
 @syncodeindex tp fn


### PR DESCRIPTION
So that fwknop can build on the latest version of GNU texinfo.

See also: https://www.mail-archive.com/m4-patches@gnu.org/msg01151.html