### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/client/log_msg.h
+++ b/client/log_msg.h
@@ -38,7 +38,11 @@ enum
     LOG_VERBOSITY_INFO,         /*!< Constant to define a INFO message */
     LOG_VERBOSITY_DEBUG,        /*!< Constant to define a DEBUG message */
     LOG_LAST_VERBOSITY
+#ifdef __FreeBSD__
+};
+#else
 } log_level_t;
+#endif
 
 #define LOG_DEFAULT_VERBOSITY   LOG_VERBOSITY_NORMAL    /*!< Default verbosity to use */
 


### PR DESCRIPTION
This fixes a duplicate symbol error: "ld: error: duplicate symbol: log_level_t"