### PR TITLE
Remove use of obsolute setcontentsaftertitlepage

### DIFF
--- a/doc/libfko.texi
+++ b/doc/libfko.texi
@@ -4,9 +4,6 @@
 @include version.texi
 @settitle Firewall Knock Operator Library - libfko
 @c @setchapternewpage odd
-@ifnothtml
-@setcontentsaftertitlepage
-@end ifnothtml
 @finalout
 @c Unify some of the indices.
 @syncodeindex tp fn


### PR DESCRIPTION
This fix comes from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=997145 :

"Later autoconf versions such as 2.71 do not include the command to @setcontentsaftertitlepage for html documents anymore.  As this is mostly cosmetic, an easy fix could be to simply stop providing this in the documentation."

-- Étienne Mollier