### PR TITLE
Add missing /etc/gai.conf to AppArmor profile

### DIFF
--- a/extras/apparmor/usr.sbin.fwknopd
+++ b/extras/apparmor/usr.sbin.fwknopd
@@ -23,6 +23,7 @@ include <tunables/global>
   /bin/dash rix,
   /etc/fwknop/access.conf r,
   /etc/fwknop/fwknopd.conf r,
+  /etc/gai.conf r,
   /etc/host.conf r,
   /etc/nsswitch.conf r,
   /etc/passwd r,


### PR DESCRIPTION
Appears to be requested/needed on Debian unstable.