### PR TITLE
Fix compile warnings

### DIFF
--- a/client/getpasswd.c
+++ b/client/getpasswd.c
@@ -218,7 +218,7 @@ get_key_file(char *key, int *key_len, const char *key_file,
     fko_ctx_t ctx, const fko_cli_options_t *options)
 {
     FILE           *pwfile_ptr;
-    unsigned int    numLines = 0, i = 0, found_dst;
+    unsigned int    i = 0, found_dst;
 
     char            conf_line_buf[MAX_LINE_LEN] = {0};
     char            tmp_char_buf[MAX_LINE_LEN]  = {0};
@@ -234,7 +234,6 @@ get_key_file(char *key, int *key_len, const char *key_file,
 
     while ((fgets(conf_line_buf, MAX_LINE_LEN, pwfile_ptr)) != NULL)
     {
-        numLines++;
         conf_line_buf[MAX_LINE_LEN-1] = '\0';
         lptr = conf_line_buf;
 

--- a/lib/fko_message.c
+++ b/lib/fko_message.c
@@ -36,7 +36,7 @@ have_allow_ip(const char *msg)
 {
     const char         *ndx     = msg;
     char                ip_str[MAX_IPV4_STR_LEN];
-    int                 dot_ctr = 0, char_ctr = 0;
+    int                 char_ctr = 0;
     int                 res     = FKO_SUCCESS;
 
     while(*ndx != ',' && *ndx != '\0')
@@ -48,9 +48,7 @@ have_allow_ip(const char *msg)
             res = FKO_ERROR_INVALID_ALLOW_IP;
             break;
         }
-        if(*ndx == '.')
-            dot_ctr++;
-        else if(isdigit((int)(unsigned char)*ndx) == 0)
+        if(isdigit((int)(unsigned char)*ndx) == 0)
         {
             res = FKO_ERROR_INVALID_ALLOW_IP;
             break;


### PR DESCRIPTION
Fix two warnings that happen with "Apple clang version 15.0.0 (clang-1500.1.0.2.5)".  With this commit the client builds on macOS with zero warnings.