### PR TITLE
TOTP integration

### DIFF
--- a/client/cmd_opts.h
+++ b/client/cmd_opts.h
@@ -160,7 +160,6 @@ static struct option cmd_opts[] =
     {"version",             0, NULL, 'V'},
     {"wget-cmd",            1, NULL, 'w'},
     {"totp",                0, NULL, USE_TOTP},
-    // TODO: add TOTP cmdline option
     {0, 0, 0, 0}
 };
 

--- a/client/cmd_opts.h
+++ b/client/cmd_opts.h
@@ -158,6 +158,7 @@ static struct option cmd_opts[] =
     {"verbose",             0, NULL, 'v'},
     {"version",             0, NULL, 'V'},
     {"wget-cmd",            1, NULL, 'w'},
+    // TODO: add TOTP cmdline option
     {0, 0, 0, 0}
 };
 

--- a/client/cmd_opts.h
+++ b/client/cmd_opts.h
@@ -66,7 +66,7 @@ enum {
     FD_SET_STDIN,
     FD_SET_ALT,
     FAULT_INJECTION_TAG,
-    TOTP_MODE,
+    USE_TOTP,
 
     /* Put GPG-related items below the following line */
     GPG_ENCRYPTION      = 0x200,
@@ -159,7 +159,7 @@ static struct option cmd_opts[] =
     {"verbose",             0, NULL, 'v'},
     {"version",             0, NULL, 'V'},
     {"wget-cmd",            1, NULL, 'w'},
-    {"totp",                0, NULL, TOTP_MODE},
+    {"totp",                0, NULL, USE_TOTP},
     // TODO: add TOTP cmdline option
     {0, 0, 0, 0}
 };

--- a/client/cmd_opts.h
+++ b/client/cmd_opts.h
@@ -66,6 +66,7 @@ enum {
     FD_SET_STDIN,
     FD_SET_ALT,
     FAULT_INJECTION_TAG,
+    TOTP_MODE,
 
     /* Put GPG-related items below the following line */
     GPG_ENCRYPTION      = 0x200,
@@ -158,6 +159,7 @@ static struct option cmd_opts[] =
     {"verbose",             0, NULL, 'v'},
     {"version",             0, NULL, 'V'},
     {"wget-cmd",            1, NULL, 'w'},
+    {"totp",                0, NULL, TOTP_MODE},
     // TODO: add TOTP cmdline option
     {0, 0, 0, 0}
 };

--- a/client/config_init.c
+++ b/client/config_init.c
@@ -2662,6 +2662,7 @@ usage(void)
       "     --time-offset-minus     Subtract time from outgoing SPA packet\n"
       "                             timestamp.\n"
       // TODO: help function for TOTP
+      "     --totp                  Use TOTP.\n"
     );
 
     return;

--- a/client/config_init.c
+++ b/client/config_init.c
@@ -2470,6 +2470,10 @@ config_init(fko_cli_options_t *options, int argc, char **argv)
                 options->input_fd = strtol_wrapper(optarg, 0,
                         -1, EXIT_UPON_ERR, &is_err);
                 break;
+            // TODO: add TOTP case
+            case TOTP_MODE:
+                options->totp_mode = 1;
+                break;
             default:
                 usage();
                 exit(EXIT_FAILURE);
@@ -2657,6 +2661,7 @@ usage(void)
       "     --time-offset-plus      Add time to outgoing SPA packet timestamp.\n"
       "     --time-offset-minus     Subtract time from outgoing SPA packet\n"
       "                             timestamp.\n"
+      // TODO: help function for TOTP
     );
 
     return;

--- a/client/config_init.c
+++ b/client/config_init.c
@@ -2670,7 +2670,6 @@ usage(void)
       "     --time-offset-plus      Add time to outgoing SPA packet timestamp.\n"
       "     --time-offset-minus     Subtract time from outgoing SPA packet\n"
       "                             timestamp.\n"
-      // TODO: help function for TOTP
       "     --totp                  Use TOTP.\n"
     );
 

--- a/client/config_init.c
+++ b/client/config_init.c
@@ -132,6 +132,7 @@ enum
     FWKNOP_CLI_ARG_RESOLVE_IP_HTTPS,
     FWKNOP_CLI_ARG_RESOLVE_HTTP_ONLY,
     FWKNOP_CLI_ARG_WGET_CMD,
+    FWKNOP_CLI_ARG_TOTP_CODE,
     FWKNOP_CLI_ARG_NO_SAVE_ARGS,
     FWKNOP_CLI_LAST_ARG
 } fwknop_cli_arg_t;
@@ -2470,9 +2471,10 @@ config_init(fko_cli_options_t *options, int argc, char **argv)
                 options->input_fd = strtol_wrapper(optarg, 0,
                         -1, EXIT_UPON_ERR, &is_err);
                 break;
-            // TODO: add TOTP case
+            //// TODO: add TOTP case
             case TOTP_MODE:
                 options->totp_mode = 1;
+                //// TODO: parse TOTP from cmdline
                 break;
             default:
                 usage();

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -32,6 +32,7 @@
 #include "utils.h"
 #include "getpasswd.h"
 
+#include <openssl/evp.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 
@@ -391,6 +392,24 @@ main(int argc, char **argv)
     }
 
     // TODO: add PBKDF2 if TOTP option is specified
+    if(options.totp_mode)
+    {
+        log_msg(LOG_VERBOSITY_NORMAL, "Using TOTP");
+
+        // TODO: make dynamic
+        char *totp_buf = NULL;
+        totp_buf = getpasswd("Enter TOTP: ", options.input_fd);
+        key_len = 16;
+
+        // int passlen = 16;
+        // TODO: should I use the EVP methods? https://docs.openssl.org/master/man7/EVP_KDF-PBKDF2/
+        // ref: https://docs.openssl.org/1.1.1/man3/PKCS5_PBKDF2_HMAC/
+        // PKCS5_PBKDF2_HMAC_SHA1(totp_buf, passlen, NULL, 0, 1000, key_len, key);
+    } 
+    else
+    {
+        log_msg(LOG_VERBOSITY_NORMAL, "Not using TOTP :(");
+    }
 
     /* Finalize the context data (encrypt and encode the SPA data)
     */

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -1272,12 +1272,10 @@ get_totp(fko_ctx_t ctx, fko_cli_options_t *options,
         }
         /* TODO: ensure the length of the input */
         memcpy(totp, key_tmp, 6);
-
-        log_msg(LOG_VERBOSITY_NORMAL, "Read TOTP from user: %s", key_tmp);
     }
     else
     {
-        log_msg(LOG_DEFAULT_VERBOSITY, "Did not read TOTP from user");
+        log_msg(LOG_VERBOSITY_ERROR, "[-] Could not read TOTP from user.");
     }
 }
 

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -390,6 +390,8 @@ main(int argc, char **argv)
         key_len = 16;
     }
 
+    // TODO: add PBKDF2 if TOTP option is specified
+
     /* Finalize the context data (encrypt and encode the SPA data)
     */
     res = fko_spa_data_final(ctx, key, key_len, hmac_key, hmac_key_len);

--- a/client/fwknop.c
+++ b/client/fwknop.c
@@ -32,7 +32,6 @@
 #include "utils.h"
 #include "getpasswd.h"
 
-#include <openssl/evp.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 

--- a/client/fwknop_common.h
+++ b/client/fwknop_common.h
@@ -86,6 +86,7 @@ typedef struct fko_cli_options
     char args_save_file[MAX_PATH_LEN];
     int  no_save_args;
     int  use_hmac;
+    int  use_totp;
     char spa_server_str[MAX_SERVER_STR_LEN];  /* may be a hostname */
     char allow_ip_str[MAX_IPV4_STR_LEN];
     char spoof_ip_src_str[MAX_IPV4_STR_LEN];
@@ -112,6 +113,13 @@ typedef struct fko_cli_options
     int  have_hmac_key;
     int  have_hmac_base64_key;
     int  hmac_type;
+    /* TOTP key is never read from the .fwknoprc file, but this is needed for key generation
+    */
+    char totp_key[MAX_KEY_LEN+1];
+    char totp_key_base32[MAX_KEY_LEN+1];
+    int  totp_key_len;
+    int  have_totp_key;
+    int  have_base64_totp_key;
 
     /* NAT access
     */
@@ -141,10 +149,6 @@ typedef struct fko_cli_options
 
     short digest_type;
     int encryption_mode;
-    //// TODO: TOTP
-    int totp_mode;
-    //// TODO: refactor to use a constant
-    char totp_code[8];
 
     int spa_icmp_type;  /* only used in '-P icmp' mode */
     int spa_icmp_code;  /* only used in '-P icmp' mode */

--- a/client/fwknop_common.h
+++ b/client/fwknop_common.h
@@ -141,6 +141,7 @@ typedef struct fko_cli_options
 
     short digest_type;
     int encryption_mode;
+    // TODO: TOTP
 
     int spa_icmp_type;  /* only used in '-P icmp' mode */
     int spa_icmp_code;  /* only used in '-P icmp' mode */

--- a/client/fwknop_common.h
+++ b/client/fwknop_common.h
@@ -142,6 +142,7 @@ typedef struct fko_cli_options
     short digest_type;
     int encryption_mode;
     // TODO: TOTP
+    int totp_mode;
 
     int spa_icmp_type;  /* only used in '-P icmp' mode */
     int spa_icmp_code;  /* only used in '-P icmp' mode */

--- a/client/fwknop_common.h
+++ b/client/fwknop_common.h
@@ -141,8 +141,10 @@ typedef struct fko_cli_options
 
     short digest_type;
     int encryption_mode;
-    // TODO: TOTP
+    //// TODO: TOTP
     int totp_mode;
+    //// TODO: refactor to use a constant
+    char totp_code[8];
 
     int spa_icmp_type;  /* only used in '-P icmp' mode */
     int spa_icmp_code;  /* only used in '-P icmp' mode */

--- a/client/getpasswd.c
+++ b/client/getpasswd.c
@@ -110,6 +110,8 @@ read_passwd_from_stream(FILE *stream)
     return password;
 }
 
+// TODO: get TOTP from user, basicaly just need to specify the format
+
 /**
  * @brief Function for accepting password input from users
  *

--- a/client/getpasswd.c
+++ b/client/getpasswd.c
@@ -110,8 +110,6 @@ read_passwd_from_stream(FILE *stream)
     return password;
 }
 
-// TODO: get TOTP from user, basicaly just need to specify the format
-
 /**
  * @brief Function for accepting password input from users
  *

--- a/common/fko_util.c
+++ b/common/fko_util.c
@@ -912,6 +912,7 @@ dump_ctx_to_buffer(fko_ctx_t ctx, char *dump_buf, size_t dump_buf_len)
     char       *enc_data        = NULL;
     char       *hmac_data       = NULL;
     char       *spa_digest      = NULL;
+    char       *totp            = NULL;
 #if HAVE_LIBGPGME
     char          *gpg_signer        = NULL;
     char          *gpg_recip         = NULL;
@@ -955,6 +956,7 @@ dump_ctx_to_buffer(fko_ctx_t ctx, char *dump_buf, size_t dump_buf_len)
         RETURN_ON_FKO_ERROR(err, fko_get_spa_message(ctx, &spa_message));
         RETURN_ON_FKO_ERROR(err, fko_get_spa_nat_access(ctx, &nat_access));
         RETURN_ON_FKO_ERROR(err, fko_get_spa_server_auth(ctx, &server_auth));
+        RETURN_ON_FKO_ERROR(err, fko_get_totp(ctx, &totp));
         RETURN_ON_FKO_ERROR(err, fko_get_spa_client_timeout(ctx, &client_timeout));
         RETURN_ON_FKO_ERROR(err, fko_get_spa_digest_type(ctx, &digest_type));
         RETURN_ON_FKO_ERROR(err, fko_get_spa_hmac_type(ctx, &hmac_type));
@@ -1012,6 +1014,7 @@ dump_ctx_to_buffer(fko_ctx_t ctx, char *dump_buf, size_t dump_buf_len)
         cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, " Message String: %s\n", spa_message == NULL ? NULL_STRING : spa_message);
         cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, "     Nat Access: %s\n", nat_access == NULL ? NULL_STRING : nat_access);
         cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, "    Server Auth: %s\n", server_auth == NULL ? NULL_STRING : server_auth);
+        cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, "           TOTP: %s\n", totp == NULL ? NULL_STRING : totp);
         cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, " Client Timeout: %u\n", client_timeout);
         cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, "    Digest Type: %u (%s)\n", digest_type, digest_str);
         cp += append_msg_to_buf(dump_buf+cp, dump_buf_len-cp, "      HMAC Type: %u (%s)\n", hmac_type, hmac_type == 0 ? "None" : hmac_str);

--- a/common/fko_util.c
+++ b/common/fko_util.c
@@ -706,6 +706,28 @@ append_msg_to_buf(char *buf, size_t buf_size, const char* msg, ...)
     return bytes_written;
 }
 
+/* Determine if a buffer contains only characters from the base32
+ * encoding set
+*/
+int
+is_base32(const unsigned char * const buf, const unsigned short int len)
+{
+    unsigned short int  i;
+    int                 rv = 1;
+
+    for(i=0; i<len; i++)
+    {
+        /* the last check is a modified version of isdigit() in range 2-7*/
+        if(!(isupper(buf[i]) || buf[i] == '=' || (buf[i] >= 50 && buf[i] <= 55)))
+        {
+            rv = 0;
+            break;
+        }
+    }
+
+    return rv;
+}
+
 /* Determine if a buffer contains only characters from the base64
  * encoding set
 */

--- a/common/fko_util.h
+++ b/common/fko_util.h
@@ -42,6 +42,7 @@ int     is_valid_encoded_msg_len(const int len);
 int     is_valid_pt_msg_len(const int len);
 int     is_valid_ipv4_addr(const char * const ip_str, const int len);
 int     is_valid_hostname(const char * const hostname_str, const int len);
+int     is_base32(const unsigned char * const buf, const unsigned short int len);
 int     is_base64(const unsigned char * const buf, const unsigned short int len);
 void    hex_dump(const unsigned char *data, const int size);
 int     enc_mode_strtoint(const char *enc_mode_str);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -9,7 +9,7 @@ libfko_source_files = \
     fko_user.c fko_user.h md5.c md5.h rijndael.c rijndael.h sha1.c \
     sha1.h sha2.c sha2.h sha3.c sha3.h fko_context.h fko_state.h \
     gpgme_funcs.c gpgme_funcs.h \
-    totp.c
+    totp.c totp.h
 
 if WANT_C_UNIT_TESTS
 noinst_PROGRAMS     = fko_utests

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,7 +8,8 @@ libfko_source_files = \
     fko.h fko_limits.h fko_timestamp.c fko_hmac.c hmac.c hmac.h \
     fko_user.c fko_user.h md5.c md5.h rijndael.c rijndael.h sha1.c \
     sha1.h sha2.c sha2.h sha3.c sha3.h fko_context.h fko_state.h \
-    gpgme_funcs.c gpgme_funcs.h
+    gpgme_funcs.c gpgme_funcs.h \
+    totp.c
 
 if WANT_C_UNIT_TESTS
 noinst_PROGRAMS     = fko_utests

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES     = libfko.la
 
 libfko_source_files = \
-    base64.c base64.h cipher_funcs.c cipher_funcs.h digest.c digest.h \
+    base32.c base32.h base64.c base64.h cipher_funcs.c cipher_funcs.h digest.c digest.h \
     fko_client_timeout.c fko_common.h fko_digest.c fko_encode.c \
     fko_decode.c fko_encryption.c fko_error.c fko_funcs.c fko_message.c \
     fko_message.h fko_nat_access.c fko_rand_value.c fko_server_auth.c \

--- a/lib/base32.c
+++ b/lib/base32.c
@@ -1,0 +1,69 @@
+#include "base32.h"
+
+static unsigned char map3[] = {
+    0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0xff, 0xff, // starts from 50
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 
+    0x19
+};
+
+int
+b32_encode(unsigned char *in, char *out, int in_len)
+{
+    static const char b32[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    unsigned i_bits = 0;
+    int i_shift = 0;
+    int bytes_remaining = in_len;
+
+    char *dst = out;
+
+    if (in_len > 0) {
+        while (bytes_remaining) {
+            i_bits = (i_bits << 8) + *in++;
+            bytes_remaining--;
+            i_shift += 8;
+
+            /* concat 5 8-bit input groups */
+            do {
+                *dst++ = b32[(i_bits << 5 >> i_shift) & 0x1f];
+                i_shift -= 5;
+            } while (i_shift > 5 || (bytes_remaining == 0 && i_shift > 0));
+        }
+    }
+
+    *dst = '\0';
+
+    return(dst - out);
+}
+
+int
+b32_decode(const char *in, unsigned char *out)
+{
+    int i, bits;
+    unsigned long v;
+    unsigned char *dst = out;
+
+    v = 0, bits = 0;
+    for (i = 0; in[i] && in[i] != '='; i++) {
+        unsigned int index= in[i]-50;
+
+        if (index>=(sizeof(map3)/sizeof(map3[0])) || map3[index] == 0xff)
+            return(-1);
+
+        v = (v << 5) + map3[index];
+        bits += 5;
+
+        /* a bit of a hacky way, but it works */
+        while (bits >= 8) {
+            *dst++ = (v >> (bits - 8)) & 0xff; 
+            bits -= 8;
+        }
+    }
+
+    *dst = '\0';
+
+    return(dst - out);
+}

--- a/lib/base32.c
+++ b/lib/base32.c
@@ -1,4 +1,34 @@
+/**
+ * \file lib/base32.c
+ *
+ * \brief Implementation of the Base32 encode/decode algorithms.
+ */
+
+/*  Fwknop is developed primarily by the people listed in the file 'AUTHORS'.
+ *  Copyright (C) 2009-2015 fwknop developers and contributors. For a full
+ *  list of contributors, see the file 'CREDITS'.
+ *
+ *  License (GNU General Public License):
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ *  USA
+ *
+ *****************************************************************************
+*/
 #include "base32.h"
+#include "fko_common.h"
 
 static unsigned char map3[] = {
     0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0xff, 0xff, // starts from 50
@@ -8,6 +38,11 @@ static unsigned char map3[] = {
     0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 
     0x19
 };
+
+#ifdef HAVE_C_UNIT_TESTS /* LCOV_EXCL_START */
+#include "cunit_common.h"
+DECLARE_TEST_SUITE(base32_test, "Utility functions test suite");
+#endif /* LCOV_EXCL_STOP */
 
 int
 b32_encode(unsigned char *in, char *out, int in_len)
@@ -67,3 +102,114 @@ b32_decode(const char *in, unsigned char *out)
 
     return(dst - out);
 }
+
+#ifdef HAVE_C_UNIT_TESTS /* LCOV_EXCL_START */
+DECLARE_UTEST(test_base32_encode, "test base32 encoding functions")
+{
+    char test_str[32] = {0};
+    char test_out[32] = {0};
+    char expected_out1[32] = {0};
+    char expected_out2[32] = {0};
+    char expected_out3[32] = {0};
+    char expected_out4[32] = {0};
+    char expected_out5[32] = {0};
+    char expected_out6[32] = {0};
+    char expected_out7[32] = {0};
+
+    strcpy(expected_out1, "");
+    strcpy(expected_out2, "MY");
+    strcpy(expected_out3, "MZXQ");
+    strcpy(expected_out4, "MZXW6");
+    strcpy(expected_out5, "MZXW6YQ");
+    strcpy(expected_out6, "MZXW6YTB");
+    strcpy(expected_out7, "MZXW6YTBOI");
+
+    strcpy(test_str, "");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out1) == 0);
+
+    strcpy(test_str, "f");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out2) == 0);
+
+    strcpy(test_str, "fo");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out3) == 0);
+
+    strcpy(test_str, "foo");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out4) == 0);
+
+    strcpy(test_str, "foob");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out5) == 0);
+
+    strcpy(test_str, "fooba");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out6) == 0);
+
+    strcpy(test_str, "foobar");
+    b32_encode((unsigned char *)test_str, test_out, strlen(test_str));
+    CU_ASSERT(strcmp(test_out, expected_out7) == 0);
+
+}
+
+DECLARE_UTEST(test_base32_decode, "test base32 decoding functions")
+{
+    char test_str[32] = {0};
+    char test_out[32] = {0};
+    char expected_out1[32] = {0};
+    char expected_out2[32] = {0};
+    char expected_out3[32] = {0};
+    char expected_out4[32] = {0};
+    char expected_out5[32] = {0};
+    char expected_out6[32] = {0};
+    char expected_out7[32] = {0};
+
+    strcpy(expected_out1, "");
+    strcpy(expected_out2, "f");
+    strcpy(expected_out3, "fo");
+    strcpy(expected_out4, "foo");
+    strcpy(expected_out5, "foob");
+    strcpy(expected_out6, "fooba");
+    strcpy(expected_out7, "foobar");
+
+    strcpy(test_str, "");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out1) == 0);
+
+    strcpy(test_str, "MY");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out2) == 0);
+
+    strcpy(test_str, "MZXQ");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out3) == 0);
+
+    strcpy(test_str, "MZXW6");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out4) == 0);
+
+    strcpy(test_str, "MZXW6YQ");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out5) == 0);
+
+    strcpy(test_str, "MZXW6YTB");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out6) == 0);
+
+    strcpy(test_str, "MZXW6YTBOI");
+    b32_decode(test_str, (unsigned char *)test_out);
+    CU_ASSERT(strcmp(test_out, expected_out7) == 0);
+}
+
+int register_base32_test(void)
+{
+    ts_init(&TEST_SUITE(base32_test), TEST_SUITE_DESCR(base32_test), NULL, NULL);
+    ts_add_utest(&TEST_SUITE(base32_test), UTEST_FCT(test_base32_encode), UTEST_DESCR(test_base32_encode));
+    ts_add_utest(&TEST_SUITE(base32_test), UTEST_FCT(test_base32_decode), UTEST_DESCR(test_base32_decode));
+
+    return register_ts(&TEST_SUITE(base32_test));
+}
+#endif /* LCOV_EXCL_STOP */
+/***EOF***/

--- a/lib/base32.h
+++ b/lib/base32.h
@@ -1,0 +1,11 @@
+#ifndef BASE32_H
+#define BASE32_H 1
+
+/* Prototypes
+*/
+int b32_encode(unsigned char *in, char *out, int in_len);
+int b32_decode(const char *in, unsigned char *out);
+
+#endif /* BASE32_H */
+
+/***EOF***/

--- a/lib/base32.h
+++ b/lib/base32.h
@@ -1,3 +1,32 @@
+/**
+ * \file lib/base32.h
+ *
+ * \brief Header for the fwknop base32.c
+ */
+
+/*  Fwknop is developed primarily by the people listed in the file 'AUTHORS'.
+ *  Copyright (C) 2009-2015 fwknop developers and contributors. For a full
+ *  list of contributors, see the file 'CREDITS'.
+ *
+ *  License (GNU General Public License):
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+ *  USA
+ *
+ *****************************************************************************
+*/
 #ifndef BASE32_H
 #define BASE32_H 1
 

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -707,6 +707,24 @@ DLL_API int fko_totp_key_derivation(unsigned int totp_code, char **key, int *key
 DLL_API int fko_totp_from_secret(unsigned int *totp_code, const char * const secret, unsigned long *timestamp, char *time_step);
 
 /**
+ * \brief TODO: TOTP
+ *
+ * \param TODO: TOTP
+ *
+ * \return TODO: TOTP
+ */
+DLL_API int fko_set_totp(fko_ctx_t ctx, const char * const totp_code);
+
+/**
+ * \brief TODO: TOTP
+ *
+ * \param TODO: TOTP
+ *
+ * \return TODO: TOTP
+ */
+DLL_API int fko_get_totp(fko_ctx_t ctx, char **totp_code);
+
+/**
  * \brief generates random keys
  *
  * \param key_base64 pass a pointer into the function to be filled with the generated key
@@ -719,7 +737,38 @@ DLL_API int fko_totp_from_secret(unsigned int *totp_code, const char * const sec
  */
 DLL_API int fko_key_gen(char * const key_base64, const int key_len,
         char * const hmac_key_base64, const int hmac_key_len,
-        const int hmac_type);
+        const int hmac_type, char * const totp_key_base32, const int totp_key_len);
+
+/**
+ * \brief Encodes text or binary data into base32
+ *
+ * Function takes text or binary data and returns a base32 encoded string.
+ * This implements base32 encoding as per rfc 4648.
+ * (This is not the url safe encoding scheme)
+ *
+ * \param in Pointer to input data.  May be text or binary data
+ * \param out Pointer to the base32 encoded data
+ * \param in_length Size in bytes of the input
+ *
+ * \return Returns length of base32 encoded output
+ * \todo add CUnit test of base32 encoding: https://tools.ietf.org/html/rfc4648
+ */
+DLL_API int fko_base32_encode(unsigned char * const in, char * const out, int in_len);
+
+/**
+ * \brief Decodes base32 into text or binary data
+ *
+ * Function takes a base32 encoded string and returns the resulting text or binary data
+ * This implements base32 decoding as per rfc 4648.
+ * (This is not the url safe encoding scheme)
+ *
+ * \param in Pointer to input data.  Must be base32 encoded
+ * \param out Pointer to the resulting data
+ *
+ * \return Returns length in bytes of decoded output
+ * \todo add CUnit test of base32 decoding: https://tools.ietf.org/html/rfc4648
+ */
+DLL_API int fko_base32_decode(const char * const in, unsigned char *out);
 
 /**
  * \brief Encodes text or binary data into base64

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -695,7 +695,7 @@ DLL_API int fko_encryption_type(const char * const enc_data);
  *
  * \return TODO: TOTP
  */
-DLL_API int fko_totp();
+DLL_API int fko_totp(unsigned int *totp_code);
 
 /**
  * \brief generates random keys

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -689,6 +689,15 @@ DLL_API const char* fko_errstr(const int err_code);
 DLL_API int fko_encryption_type(const char * const enc_data);
 
 /**
+ * \brief TODO: TOTP
+ *
+ * \param TODO: TOTP
+ *
+ * \return TODO: TOTP
+ */
+DLL_API int totp();
+
+/**
  * \brief generates random keys
  *
  * \param key_base64 pass a pointer into the function to be filled with the generated key

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -695,7 +695,16 @@ DLL_API int fko_encryption_type(const char * const enc_data);
  *
  * \return TODO: TOTP
  */
-DLL_API int fko_totp(unsigned int *totp_code, const char * const secret);
+DLL_API int fko_totp_key_derivation(unsigned int totp_code, char **key, int *key_len);
+
+/**
+ * \brief TODO: TOTP
+ *
+ * \param TODO: TOTP
+ *
+ * \return TODO: TOTP
+ */
+DLL_API int fko_totp_from_secret(unsigned int *totp_code, const char * const secret, unsigned long *timestamp, char *time_step);
 
 /**
  * \brief generates random keys

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -695,15 +695,6 @@ DLL_API int fko_encryption_type(const char * const enc_data);
  *
  * \return TODO: TOTP
  */
-DLL_API int fko_totp_key_derivation(unsigned int totp_code, char **key, int *key_len);
-
-/**
- * \brief TODO: TOTP
- *
- * \param TODO: TOTP
- *
- * \return TODO: TOTP
- */
 DLL_API int fko_totp_from_secret(unsigned int *totp_code, const char * const secret, unsigned long *timestamp, char *time_step);
 
 /**
@@ -1470,6 +1461,7 @@ int register_ts_digest_test(void);
 int register_ts_aes_test(void);
 int register_utils_test(void);
 int register_base64_test(void);
+int register_base32_test(void);
 #endif
 
 #endif /* FKO_H */

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -695,7 +695,7 @@ DLL_API int fko_encryption_type(const char * const enc_data);
  *
  * \return TODO: TOTP
  */
-DLL_API int fko_totp(unsigned int *totp_code);
+DLL_API int fko_totp(unsigned int *totp_code, const char * const secret);
 
 /**
  * \brief generates random keys

--- a/lib/fko.h
+++ b/lib/fko.h
@@ -695,7 +695,7 @@ DLL_API int fko_encryption_type(const char * const enc_data);
  *
  * \return TODO: TOTP
  */
-DLL_API int totp();
+DLL_API int fko_totp();
 
 /**
  * \brief generates random keys

--- a/lib/fko_context.h
+++ b/lib/fko_context.h
@@ -74,6 +74,7 @@ struct fko_context {
     char           *nat_access;
     char           *server_auth;
     unsigned int    client_timeout;
+    char           *totp;
     /*@}*/
     /** \name FKO SPA user-settable message encoding types */
     /*@{*/

--- a/lib/fko_decode.c
+++ b/lib/fko_decode.c
@@ -561,7 +561,7 @@ fko_decode_spa_data(fko_ctx_t ctx)
             parse_msg_type,       /* SPA msg type */
             parse_msg,            /* SPA msg string */
             parse_nat_msg,        /* SPA NAT msg string */
-            parse_totp,           /* TODO: optional TOTP */
+            parse_totp,           /* optional TOTP field */
             parse_server_auth,    /* optional server authentication method */
             parse_client_timeout  /* client defined timeout */
           };

--- a/lib/fko_decode.c
+++ b/lib/fko_decode.c
@@ -33,7 +33,7 @@
 #include "base64.h"
 #include "digest.h"
 
-#define FIELD_PARSERS 9
+#define FIELD_PARSERS 10
 
 /* Char used to separate SPA fields in an SPA packet */
 #define SPA_FIELD_SEPARATOR    ":"
@@ -346,6 +346,25 @@ parse_server_auth(char *tbuf, char **ndx, int *t_size, fko_ctx_t ctx)
 }
 
 static int
+parse_totp(char *tbuf, char **ndx, int *t_size, fko_ctx_t ctx)
+{
+    /* static size for TOTP */
+    *t_size = 6;
+
+    if(ctx->totp != NULL)
+        free(ctx->totp);
+
+    ctx->totp = malloc(*t_size+1);
+    if(ctx->totp == NULL)
+        return(FKO_ERROR_MEMORY_ALLOCATION);
+
+    strlcpy(ctx->totp, *ndx, *t_size+1);
+
+    *ndx += *t_size+1;
+    return FKO_SUCCESS;
+}
+
+static int
 parse_client_timeout(char *tbuf, char **ndx, int *t_size, fko_ctx_t ctx)
 {
     int         is_err;
@@ -542,6 +561,7 @@ fko_decode_spa_data(fko_ctx_t ctx)
             parse_msg_type,       /* SPA msg type */
             parse_msg,            /* SPA msg string */
             parse_nat_msg,        /* SPA NAT msg string */
+            parse_totp,           /* TODO: optional TOTP */
             parse_server_auth,    /* optional server authentication method */
             parse_client_timeout  /* client defined timeout */
           };

--- a/lib/fko_encode.c
+++ b/lib/fko_encode.c
@@ -180,6 +180,13 @@ fko_encode_spa_data(fko_ctx_t ctx)
         }
     }
 
+    if(ctx->totp != NULL)
+    {
+        offset = strlen(tbuf);
+        snprintf(((char*)tbuf+offset), FKO_ENCODE_TMP_BUF_SIZE - offset,
+                ":%s", ctx->totp);
+    }
+
     /* If we have a server_auth field set.  Add it here.
      *
     */

--- a/lib/fko_funcs.c
+++ b/lib/fko_funcs.c
@@ -365,6 +365,8 @@ fko_destroy(fko_ctx_t ctx)
     return(zero_free_rv);
 }
 
+/* TODO: initial secret generation */
+
 /* Generate Rijndael and HMAC keys from /dev/random and base64
  * encode them
 */
@@ -416,6 +418,8 @@ fko_key_gen(char * const key_base64, const int key_len,
 
     return(FKO_SUCCESS);
 }
+
+/* TODO: TOTP base32 enc/dec */
 
 /* Provide an FKO wrapper around base64 encode/decode functions
 */

--- a/lib/fko_funcs.c
+++ b/lib/fko_funcs.c
@@ -33,6 +33,7 @@
 #include "base64.h"
 #include "base32.h"
 #include "digest.h"
+#include "totp.h"
 
 /* Initialize an fko context.
 */
@@ -379,7 +380,7 @@ fko_key_gen(char * const key_base64, const int key_len,
 {
     unsigned char key[RIJNDAEL_MAX_KEYSIZE];
     unsigned char hmac_key[SHA512_BLOCK_LEN];
-    unsigned char totp_key[20]; /* TODO: make constant */
+    unsigned char totp_key[TOTP_SECRET_LEN];
     int klen      = key_len;
     int hmac_klen = hmac_key_len;
     int totp_klen = totp_key_len;
@@ -405,7 +406,7 @@ fko_key_gen(char * const key_base64, const int key_len,
 
     if(totp_key_len == FKO_DEFAULT_KEY_LEN)
     {
-        totp_klen = 20; /* TODO: make constant */
+        totp_klen = TOTP_SECRET_LEN;
     }
 
     if((klen < 1) || (klen > RIJNDAEL_MAX_KEYSIZE))
@@ -414,7 +415,8 @@ fko_key_gen(char * const key_base64, const int key_len,
     if((hmac_klen < 1) || (hmac_klen > SHA512_BLOCK_LEN))
         return(FKO_ERROR_INVALID_DATA_FUNCS_GEN_HMACLEN_VALIDFAIL);
 
-    /* TODO: TOTP checks*/
+    if((totp_key < 1) || (totp_klen > TOTP_SECRET_LEN))
+        return(FKO_ERROR_INVALID_DATA_FUNCS_GEN_KEYLEN_VALIDFAIL);
 
     get_random_data(key, klen);
     get_random_data(hmac_key, hmac_klen);

--- a/lib/fko_funcs.c
+++ b/lib/fko_funcs.c
@@ -430,7 +430,7 @@ fko_key_gen(char * const key_base64, const int key_len,
 
     b64_len = b32_encode(totp_key, totp_key_base32, totp_klen);
     if(b64_len < totp_klen)
-        return(FKO_ERROR_INVALID_DATA_FUNCS_GEN_HMAC_ENCODEFAIL);
+        return(FKO_ERROR_INVALID_DATA_FUNCS_GEN_KEY_ENCODEFAIL);
 
     return(FKO_SUCCESS);
 }

--- a/lib/fko_utests.c
+++ b/lib/fko_utests.c
@@ -22,6 +22,7 @@ static void register_test_suites(void)
     register_ts_aes_test();
     register_utils_test();
     register_base64_test();
+    register_base32_test();
 }
 
 /* The main() function for setting up and running the tests.

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -1,22 +1,7 @@
-// libfko imports
-#include "fko_common.h"
-#include "fko.h"
-#include "hmac.h"
+#include "totp.h"
 
-// others
-#include <math.h>
-#include <time.h>
-#include <stdio.h>
-#include <string.h>
-
-#define SECRET_LEN 20
-#define HMAC_LENGTH 20
-#define TIME_LEN 8
-#define DIGITS 6 // OTP digits
-#define X 30 // default time step
-#define T0 0 // default value
-
-uint32_t dynamic_truncation(unsigned char* hmac_result)
+uint32_t 
+dynamic_truncation(unsigned char* hmac_result)
 {
     uint32_t bin_code, offset;
 
@@ -31,7 +16,8 @@ uint32_t dynamic_truncation(unsigned char* hmac_result)
     return bin_code;
 }
 
-int totp()
+int 
+fko_totp()
 {
     // store the final TOTP
     uint32_t totp;

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -17,11 +17,8 @@ dynamic_truncation(unsigned char* hmac_result)
 }
 
 int 
-fko_totp()
+fko_totp(uint32_t *totp_code)
 {
-    // store the final TOTP
-    uint32_t totp;
-
     // key and counter
     uint8_t hmac_result[HMAC_LENGTH];
 
@@ -31,26 +28,25 @@ fko_totp()
 
     // configure time timestamp (T)
     uint64_t T = (time(NULL) - T0)/X;
-    char time_buf[TIME_LEN];
+    char time_buf[TIME_LEN] = {0};
 
     //// TODO: THIS SHOULD NOT BE STATIC
-    int hex_len = 4;
-    for (size_t i = 1; i <= hex_len; i++)
-    {
-        time_buf[TIME_LEN - i] = (char)(((T >> 4) % 0x10) << 4 | (T % 0x10));
-        T >>= 8;
-    }
+    // int hex_len = 4;
+    // for (size_t i = 1; i <= hex_len; i++)
+    // {
+    //     time_buf[TIME_LEN - i] = (char)(((T >> 4) % 0x10) << 4 | (T % 0x10));
+    //     T >>= 8;
+    // }
 
-    // clear the rest of the buffer
-    for (size_t i = 0; i < TIME_LEN - 1 - hex_len;++i)
-    {
-        time_buf[i] = (char)0;
-    }
+    // assign the hex values
+    time_buf[TIME_LEN - 1] = (char)0x1; // test vector 1 from RFC6238
 
-    //// TODO: hmac_sha1 returns FKO_SUCCESS
-    hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN);
+    if (hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN) != FKO_SUCCESS)
+    {
+        return 0;
+    }
 
     //// TODO: refactor
-	totp = dynamic_truncation(hmac_result) % (int)floor(pow(10.0, DIGITS)); 
-    return (int)totp;
+	*totp_code = dynamic_truncation(hmac_result) % (int)floor(pow(10.0, DIGITS)); 
+    return 1;
 }

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -1,0 +1,70 @@
+// libfko imports
+#include "fko_common.h"
+#include "fko.h"
+#include "hmac.h"
+
+// others
+#include <math.h>
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+
+#define SECRET_LEN 20
+#define HMAC_LENGTH 20
+#define TIME_LEN 8
+#define DIGITS 6 // OTP digits
+#define X 30 // default time step
+#define T0 0 // default value
+
+uint32_t dynamic_truncation(unsigned char* hmac_result)
+{
+    uint32_t bin_code, offset;
+
+    /* RFC4226 p7-8 */  
+    offset = hmac_result[HMAC_LENGTH - 1] & 0xf;
+
+    bin_code = (hmac_result[offset] & 0x7f) << 24
+    | (hmac_result[offset+1] & 0xff) << 16
+    | (hmac_result[offset+2] & 0xff) << 8
+    | (hmac_result[offset+3] & 0xff);
+
+    return bin_code;
+}
+
+int totp()
+{
+    // store the final TOTP
+    uint32_t totp;
+
+    // key and counter
+    uint8_t hmac_result[HMAC_LENGTH];
+
+    //// TODO: secret generation
+    // configure the secret (K)
+    const char secret[] = "12345678901234567890";
+
+    // configure time timestamp (T)
+    uint64_t T = (time(NULL) - T0)/X;
+    char time_buf[TIME_LEN];
+
+    //// TODO: THIS SHOULD NOT BE STATIC
+    int hex_len = 4;
+    for (size_t i = 1; i <= hex_len; i++)
+    {
+        time_buf[TIME_LEN - i] = (char)(((T >> 4) % 0x10) << 4 | (T % 0x10));
+        T >>= 8;
+    }
+
+    // clear the rest of the buffer
+    for (size_t i = 0; i < TIME_LEN - 1 - hex_len;++i)
+    {
+        time_buf[i] = (char)0;
+    }
+
+    //// TODO: hmac_sha1 returns FKO_SUCCESS
+    hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN);
+
+    //// TODO: refactor
+	totp = dynamic_truncation(hmac_result) % (int)floor(pow(10.0, DIGITS)); 
+    return (int)totp;
+}

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -77,10 +77,9 @@ fko_totp_from_secret(uint32_t *totp_code, const char * const secret, uint64_t *t
         T >>= 8;
     }
 
-    if(hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN) != FKO_SUCCESS)
+    if(hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, TOTP_SECRET_LEN) != FKO_SUCCESS)
         return 0;
 
-    //// TODO: refactor
 	*totp_code = dynamic_truncation(hmac_result) % (int)floor(pow(10.0, DIGITS)); 
     return 1;
 }

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -59,34 +59,6 @@ fko_get_totp(fko_ctx_t ctx, char **totp_code)
     return(FKO_SUCCESS);
 }
 
-/* TODO: considering passing TOTP code by reference here as well */
-
-int
-fko_totp_key_derivation(uint32_t totp_code, char **key, int *key_len)
-{
-    // convert to hex and write to char buffer
-    unsigned char totp[DIGITS] = {0};
-    for (size_t i = 1; i <= DIGITS; i++)
-    {
-        totp[DIGITS - i] = (char)('0' + (totp_code % 10));
-        totp_code /= 10;
-    }
-
-    /* TODO: verify memory allocation */
-    if(key != NULL)
-        free(key);
-
-    *key = malloc(SHA256_DIGEST_LEN + 1);
-
-    // calculate and store hash
-    sha256(*key, totp, DIGITS);
-
-    // change key size to hash output length
-    *key_len = SHA256_DIGEST_LEN;
-
-    return 1;
-}
-
 /* Calculate TOTP based on initial secret and current timestamp
 */
 int 

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -16,26 +16,48 @@ dynamic_truncation(unsigned char* hmac_result)
     return bin_code;
 }
 
-int 
-fko_totp(uint32_t *totp_code, const char * const secret)
-{
-    // key and counter
-    uint8_t hmac_result[HMAC_LENGTH];
+/* TODO: considering passing TOTP code by reference here as well */
 
-    // configure time timestamp (T)
-    uint64_t T = (time(NULL) - T0)/X;
+int
+fko_totp_key_derivation(uint32_t totp_code, char **key, int *key_len)
+{
+    // convert to hex and write to char buffer
+    unsigned char totp[DIGITS] = {0};
+    for (size_t i = 1; i <= DIGITS; i++)
+    {
+        totp[DIGITS - i] = (char)('0' + (totp_code % 10));
+        totp_code /= 10;
+    }
+    /* TODO: verify memory allocation */
+    *key = malloc(SHA256_DIGEST_LEN + 1);
+
+    // calculate and store hash
+    sha256(*key, totp, DIGITS);
+
+    // change key size to hash output length
+    *key_len = SHA256_DIGEST_LEN;
+
+    return 1;
+}
+
+int 
+fko_totp_from_secret(uint32_t *totp_code, const char * const secret, uint64_t *timestamp, char *time_step)
+{
+    // HMAC-SHA1 result buffer
+    uint8_t hmac_result[HMAC_LENGTH] = {0};
+
+    // configure timestamp (T)
+    uint64_t T = (uint64_t)floor((*timestamp - T0) / X) - *time_step;
     char time_buf[TIME_LEN] = {0};
 
-    for (size_t i = 1; i <= TIME_LEN; i++)
+    for (char i = 1; i <= TIME_LEN; i++)
     {
         time_buf[TIME_LEN - i] = (char)(((T >> 4) % 0x10) << 4 | (T % 0x10));
         T >>= 8;
     }
 
-    if (hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN) != FKO_SUCCESS)
-    {
+    if(hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN) != FKO_SUCCESS)
         return 0;
-    }
 
     //// TODO: refactor
 	*totp_code = dynamic_truncation(hmac_result) % (int)floor(pow(10.0, DIGITS)); 

--- a/lib/totp.c
+++ b/lib/totp.c
@@ -17,29 +17,20 @@ dynamic_truncation(unsigned char* hmac_result)
 }
 
 int 
-fko_totp(uint32_t *totp_code)
+fko_totp(uint32_t *totp_code, const char * const secret)
 {
     // key and counter
     uint8_t hmac_result[HMAC_LENGTH];
-
-    //// TODO: secret generation
-    // configure the secret (K)
-    const char secret[] = "12345678901234567890";
 
     // configure time timestamp (T)
     uint64_t T = (time(NULL) - T0)/X;
     char time_buf[TIME_LEN] = {0};
 
-    //// TODO: THIS SHOULD NOT BE STATIC
-    // int hex_len = 4;
-    // for (size_t i = 1; i <= hex_len; i++)
-    // {
-    //     time_buf[TIME_LEN - i] = (char)(((T >> 4) % 0x10) << 4 | (T % 0x10));
-    //     T >>= 8;
-    // }
-
-    // assign the hex values
-    time_buf[TIME_LEN - 1] = (char)0x1; // test vector 1 from RFC6238
+    for (size_t i = 1; i <= TIME_LEN; i++)
+    {
+        time_buf[TIME_LEN - i] = (char)(((T >> 4) % 0x10) << 4 | (T % 0x10));
+        T >>= 8;
+    }
 
     if (hmac_sha1((const char *)time_buf, TIME_LEN, hmac_result, secret, SECRET_LEN) != FKO_SUCCESS)
     {

--- a/lib/totp.h
+++ b/lib/totp.h
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <stdint.h>
 
-#define SECRET_LEN 20
+#define TOTP_SECRET_LEN 20
 #define HMAC_LENGTH 20
 #define TIME_LEN 8
 #define DIGITS 6 // OTP digits

--- a/lib/totp.h
+++ b/lib/totp.h
@@ -1,6 +1,6 @@
 // libfko imports
 #include "fko.h"
-#include "hmac.h"
+#include "hmac.h" // already includes "digest.h"
 
 // others
 #include <math.h>
@@ -12,6 +12,6 @@
 #define SECRET_LEN 20
 #define HMAC_LENGTH 20
 #define TIME_LEN 8
-#define DIGITS 8 // OTP digits
+#define DIGITS 6 // OTP digits
 #define X 30 // default time step
 #define T0 0 // default value

--- a/lib/totp.h
+++ b/lib/totp.h
@@ -1,6 +1,10 @@
+#ifndef __TOTP_H__
+#define __TOTP_H__
+
 // libfko imports
 #include "fko.h"
-#include "hmac.h" // already includes "digest.h"
+#include "fko_common.h"
+#include "hmac.h"
 
 // others
 #include <math.h>
@@ -15,3 +19,5 @@
 #define DIGITS 6 // OTP digits
 #define X 30 // default time step
 #define T0 0 // default value
+
+#endif /* __TOTP_H__ */

--- a/lib/totp.h
+++ b/lib/totp.h
@@ -7,10 +7,11 @@
 #include <time.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
 #define SECRET_LEN 20
 #define HMAC_LENGTH 20
 #define TIME_LEN 8
-#define DIGITS 6 // OTP digits
+#define DIGITS 8 // OTP digits
 #define X 30 // default time step
 #define T0 0 // default value

--- a/lib/totp.h
+++ b/lib/totp.h
@@ -1,0 +1,16 @@
+// libfko imports
+#include "fko.h"
+#include "hmac.h"
+
+// others
+#include <math.h>
+#include <time.h>
+#include <stdio.h>
+#include <string.h>
+
+#define SECRET_LEN 20
+#define HMAC_LENGTH 20
+#define TIME_LEN 8
+#define DIGITS 6 // OTP digits
+#define X 30 // default time step
+#define T0 0 // default value

--- a/server/access.c
+++ b/server/access.c
@@ -1749,7 +1749,6 @@ parse_access_file(fko_srv_options_t *opts, char *access_filename, int *depth)
             add_acc_string(&(curr_acc->totp_key_base64), val, file_ptr, opts);
             add_acc_b64_string(&(curr_acc->totp_key), &(curr_acc->totp_key_len),
                     curr_acc->totp_key_base64, file_ptr, opts);
-            add_acc_bool(&(curr_acc->use_rijndael), "Y"); /* TODO: may refactor to use only acc->use_totp at some point */
             add_acc_bool(&(curr_acc->use_totp), "Y");
         }
         /* TOTP key */
@@ -1757,7 +1756,6 @@ parse_access_file(fko_srv_options_t *opts, char *access_filename, int *depth)
         {
             add_acc_string(&(curr_acc->totp_key), val, file_ptr, opts);
             curr_acc->totp_key_len = strlen(curr_acc->totp_key);
-            add_acc_bool(&(curr_acc->use_rijndael), "Y"); /* TODO: may refactor to use only acc->use_totp at some point */
             add_acc_bool(&(curr_acc->use_totp), "Y");
         }
         else if(CONF_VAR_IS(var, "FW_ACCESS_TIMEOUT"))

--- a/server/config_init.c
+++ b/server/config_init.c
@@ -222,7 +222,7 @@ generate_keys(fko_srv_options_t *options)
 {
     char key_base64[MAX_B64_KEY_LEN+1];
     char hmac_key_base64[MAX_B64_KEY_LEN+1];
-    char totp_key_base32[32]; /* TODO: make const */
+    char totp_key_base32[32+1]; /* TODO: make const */
 
     FILE  *key_gen_file_ptr = NULL;
     int res;
@@ -241,6 +241,7 @@ generate_keys(fko_srv_options_t *options)
     /* Zero out the key buffers */
     memset(key_base64, 0x00, sizeof(key_base64));
     memset(hmac_key_base64, 0x00, sizeof(hmac_key_base64));
+    memset(totp_key_base32, 0x00, sizeof(totp_key_base32));
 
     /* Generate the key through libfko */
     res = fko_key_gen(key_base64, options->key_len,

--- a/server/config_init.c
+++ b/server/config_init.c
@@ -222,6 +222,7 @@ generate_keys(fko_srv_options_t *options)
 {
     char key_base64[MAX_B64_KEY_LEN+1];
     char hmac_key_base64[MAX_B64_KEY_LEN+1];
+    char totp_key_base32[32]; /* TODO: make const */
 
     FILE  *key_gen_file_ptr = NULL;
     int res;
@@ -244,7 +245,7 @@ generate_keys(fko_srv_options_t *options)
     /* Generate the key through libfko */
     res = fko_key_gen(key_base64, options->key_len,
             hmac_key_base64, options->hmac_key_len,
-            options->hmac_type);
+            options->hmac_type, totp_key_base32, options->totp_key_len);
 
     if(res != FKO_SUCCESS)
     {
@@ -261,16 +262,16 @@ generate_keys(fko_srv_options_t *options)
                 options->key_gen_file, strerror(errno));
             clean_exit(options, NO_FW_CLEANUP, EXIT_FAILURE);
         }
-        fprintf(key_gen_file_ptr, "KEY_BASE64: %s\nHMAC_KEY_BASE64: %s\n",
-            key_base64, hmac_key_base64);
+        fprintf(key_gen_file_ptr, "KEY_BASE64: %s\nHMAC_KEY_BASE64: %s\nTOTP_KEY_BASE32: %s\n",
+            key_base64, hmac_key_base64, totp_key_base32);
         fclose(key_gen_file_ptr);
         fprintf(stdout, "[+] Wrote Rijndael and HMAC keys to: %s",
             options->key_gen_file);
     }
     else
     {
-        fprintf(stdout, "KEY_BASE64: %s\nHMAC_KEY_BASE64: %s\n",
-                key_base64, hmac_key_base64);
+        fprintf(stdout, "KEY_BASE64: %s\nHMAC_KEY_BASE64: %s\nTOTP_KEY_BASE32: %s\n",
+                key_base64, hmac_key_base64, totp_key_base32);
     }
     clean_exit(options, NO_FW_CLEANUP, EXIT_SUCCESS);
 }

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -403,6 +403,10 @@ typedef struct acc_stanza
     int                  hmac_key_len;
     char                *hmac_key_base64;
     int                  hmac_type;
+    char                *totp_key;
+    int                  totp_key_len;
+    char                *totp_key_base64; // TODO: RFC 4648 defines Base32 as the standard encoding
+    unsigned char        use_totp;
     unsigned char        use_rijndael;
     int                  fw_access_timeout;
     int                  max_fw_timeout;

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -405,7 +405,7 @@ typedef struct acc_stanza
     int                  hmac_type;
     char                *totp_key;
     int                  totp_key_len;
-    char                *totp_key_base64; // TODO: RFC 4648 defines Base32 as the standard encoding
+    char                *totp_key_base32;
     unsigned char        use_totp;
     unsigned char        use_rijndael;
     int                  fw_access_timeout;
@@ -628,6 +628,7 @@ typedef struct spa_data
     char            pkt_destination_ip[MAX_IPV4_STR_LEN];
     char            spa_message_remain[1024]; /* --DSS FIXME: arbitrary bounds */
     char           *nat_access;
+    char           *totp;
     char           *server_auth;
     unsigned int    client_timeout;
     unsigned int    fw_access_timeout;
@@ -684,6 +685,7 @@ typedef struct fko_srv_options
     int  key_len;
     int  hmac_key_len;
     int  hmac_type;
+    int  totp_key_len;
 
 #if USE_FILE_CACHE
     struct digest_cache_list *digest_cache;   /* In-memory digest cache list */

--- a/server/incoming_spa.c
+++ b/server/incoming_spa.c
@@ -1010,6 +1010,9 @@ incoming_spa(fko_srv_options_t *opts)
         */
         enc_type = fko_encryption_type((char *)spa_pkt->packet_data);
 
+        // TODO: handle TOTP encryption branch
+        // TODO: calculate AES secret with PBKDF2
+
         if(acc->use_rijndael)
             handle_rijndael_enc(acc, spa_pkt, &spadat, &ctx,
                         &attempted_decrypt, &cmd_exec_success, enc_type,


### PR DESCRIPTION
[#354](https://github.com/mrash/fwknop/issues/354)

An attempt to integrate the Time-based One-Time Passwords (TOTP) with _fwknop_. The implementation was done according to [RFC 6238](https://www.rfc-editor.org/rfc/rfc6238), tested with common authenticator applications such as Google Authenticator. Parameters (time-step value and TOTP digits) are not currently configurable, but could be done.

To validate the TOTP, an optional field was added inside the SPA packet, that is sent to the server from the client. If the client's _access.conf_ file contains the _TOTP_BASE32_ parameter on the server, then the code is calculated and compared to the one obtained from the SPA packet data (after the HMAC verification and blob decryption).

Base32 utility functions were added into the _libfko_ library based on [RFC 4648](https://www.rfc-editor.org/rfc/rfc4648).

All the work was done as part of a [Bachelor's thesis on Single Packet Authorization](https://thesis.cs.ut.ee/ed8049c7-534a-4ba2-b422-59eb8d23250d?language=en) at the University of Tartu.