### PR TITLE
implement access setting to respect if-bound mode

### DIFF
--- a/server/access.c
+++ b/server/access.c
@@ -1957,6 +1957,9 @@ parse_access_file(fko_srv_options_t *opts, char *access_filename, int *depth)
         {
             add_acc_bool(&(curr_acc->forward_all), val);
         }
+        else if(CONF_VAR_IS(var, "PF_IF_BOUND")) {
+            add_acc_bool(&(curr_acc->pf_if_bound), val);
+        }
         else
         {
             log_msg(LOG_ERR,

--- a/server/access.c
+++ b/server/access.c
@@ -1957,8 +1957,8 @@ parse_access_file(fko_srv_options_t *opts, char *access_filename, int *depth)
         {
             add_acc_bool(&(curr_acc->forward_all), val);
         }
-        else if(CONF_VAR_IS(var, "PF_IF_BOUND")) {
-            add_acc_bool(&(curr_acc->pf_if_bound), val);
+        else if(CONF_VAR_IS(var, "PF_NO_QUICK")) {
+            add_acc_bool(&(curr_acc->pf_no_quick), val);
         }
         else
         {

--- a/server/access.conf
+++ b/server/access.conf
@@ -144,12 +144,12 @@
 # default is "N".
 #
 
-# PF_IF_BOUND            <Y/N>
+# PF_NO_QUICK               <Y/N>
 #
-# For OpenBSD PF firewall rules, this specifies whether to respect if-bound
-# mode for the generated rules. When set to "Y", this disables the "quick"
-# keyword in the PF rule, allowing the rule to be processed in if-bound mode.
-# This is useful for binding rules to specific network interfaces.
+# For OpenBSD pf firewall, this specifies to not use the "quick" keyword
+# for the generated rules. When set to "Y", the keyword is not inserted
+# and allows the firewall to keep its top to bottom flow.
+# This is useful if you want to match the packets for NAT or similar.
 # If not set here, the default is "N".
 #
 

--- a/server/access.conf
+++ b/server/access.conf
@@ -144,6 +144,15 @@
 # default is "N".
 #
 
+# PF_IF_BOUND            <Y/N>
+#
+# For OpenBSD PF firewall rules, this specifies whether to respect if-bound
+# mode for the generated rules. When set to "Y", this disables the "quick"
+# keyword in the PF rule, allowing the rule to be processed in if-bound mode.
+# This is useful for binding rules to specific network interfaces.
+# If not set here, the default is "N".
+#
+
 # GPG_HOME_DIR          <path>
 #
 # Define the path to the GnuPG directory to be used by fwknopd.  If this

--- a/server/fw_util_pf.c
+++ b/server/fw_util_pf.c
@@ -245,7 +245,7 @@ process_spa_request(const fko_srv_options_t * const opts,
             */
             memset(new_rule, 0x0, MAX_PF_NEW_RULE_LEN);
             snprintf(new_rule, MAX_PF_NEW_RULE_LEN-1,
-                acc->pf_if_bound ? PF_ADD_RULE_ARGS_IF_BOUND "\n" : PF_ADD_RULE_ARGS "\n",
+                acc->pf_no_quick ? PF_ADD_RULE_ARGS_NO_QUICK "\n" : PF_ADD_RULE_ARGS "\n",
                 ple->proto,
                 spadat->use_src_ip,
                 (fwc.use_destination ? spadat->pkt_destination_ip : PF_ANY_IP),

--- a/server/fw_util_pf.c
+++ b/server/fw_util_pf.c
@@ -244,7 +244,8 @@ process_spa_request(const fko_srv_options_t * const opts,
             /* Build the new rule string
             */
             memset(new_rule, 0x0, MAX_PF_NEW_RULE_LEN);
-            snprintf(new_rule, MAX_PF_NEW_RULE_LEN-1, PF_ADD_RULE_ARGS "\n",
+            snprintf(new_rule, MAX_PF_NEW_RULE_LEN-1,
+                acc->pf_if_bound ? PF_ADD_RULE_ARGS_IF_BOUND "\n" : PF_ADD_RULE_ARGS "\n",
                 ple->proto,
                 spadat->use_src_ip,
                 (fwc.use_destination ? spadat->pkt_destination_ip : PF_ANY_IP),

--- a/server/fw_util_pf.h
+++ b/server/fw_util_pf.h
@@ -42,7 +42,7 @@
 /* pf command args
 */
 #define PF_ADD_RULE_ARGS              "pass in quick proto %u from %s to %s port %u keep state label " EXPIRE_COMMENT_PREFIX "%u"
-#define PF_ADD_RULE_ARGS_IF_BOUND     "pass in proto %u from %s to %s port %u keep state label " EXPIRE_COMMENT_PREFIX "%u"
+#define PF_ADD_RULE_ARGS_NO_QUICK     "pass in proto %u from %s to %s port %u keep state label " EXPIRE_COMMENT_PREFIX "%u"
 #define PF_WRITE_ANCHOR_RULES_ARGS    "-a %s -f -"
 #if HAVE_EXECVP
   #define PF_LIST_ANCHOR_RULES_ARGS   "-a %s -s rules"

--- a/server/fw_util_pf.h
+++ b/server/fw_util_pf.h
@@ -42,6 +42,7 @@
 /* pf command args
 */
 #define PF_ADD_RULE_ARGS              "pass in quick proto %u from %s to %s port %u keep state label " EXPIRE_COMMENT_PREFIX "%u"
+#define PF_ADD_RULE_ARGS_IF_BOUND     "pass in proto %u from %s to %s port %u keep state label " EXPIRE_COMMENT_PREFIX "%u"
 #define PF_WRITE_ANCHOR_RULES_ARGS    "-a %s -f -"
 #if HAVE_EXECVP
   #define PF_LIST_ANCHOR_RULES_ARGS   "-a %s -s rules"

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -453,7 +453,7 @@ typedef struct acc_stanza
 
     /* PF firewall settings
     */
-    unsigned char        pf_if_bound;
+    unsigned char        pf_no_quick;
 
     struct acc_stanza   *next;
 } acc_stanza_t;

--- a/server/fwknopd_common.h
+++ b/server/fwknopd_common.h
@@ -451,6 +451,10 @@ typedef struct acc_stanza
     char                *force_snat_ip;
     unsigned char        force_masquerade;
 
+    /* PF firewall settings
+    */
+    unsigned char        pf_if_bound;
+
     struct acc_stanza   *next;
 } acc_stanza_t;
 


### PR DESCRIPTION
This is needed to match the packets after passing the rule. I implemented this in the access stanza, to have a pass through with some and allow using match out based on each access rule