### PR TITLE
Fix NFQ verdict failure by converting packet ID to host byte order

### DIFF
--- a/server/nfq_capture.c
+++ b/server/nfq_capture.c
@@ -77,7 +77,7 @@ static int process_nfq_packet(struct nfq_q_handle *qh,
          * a spa packet and can be dropped. Otherwise, let it through.
         */
         verdict = (ph->hook == NF_IP_LOCAL_IN) ? NF_DROP : NF_ACCEPT;
-        nfq_set_verdict(qh, ph->packet_id, verdict, 0, NULL);
+        nfq_set_verdict(qh, ntohl(ph->packet_id), verdict, 0, NULL);
     }
     return 0;
 }


### PR DESCRIPTION
The nfq_set_verdict function in libnetfilter_queue expects the
packet ID in Host Byte Order, as it performs its own internal
conversion to Network Byte Order (Big-Endian).

The current implementation was passing the raw Big-Endian ID
retrieved from the header directly to the library. On Little-Endian
architectures (x86_64), this resulted in a double-swap, causing
the kernel to reject verdicts with ENOENT and eventually leading
to NFQUEUE saturation and daemon silence.

This fix wraps ph->packet_id in ntohl() to ensure the library
receives the ID in the expected Host Byte Order.