### PR TITLE
Add Visual Studio 2026 project files for native Windows client build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,18 @@ android/project/jni/libfwknop/*.c
 # Erlang
 erlang/_build
 erlang/rebar.lock
+
+# MSVC / Visual Studio build output (win32/)
+win32/x64/
+win32/Win32/
+win32/libfko/
+win32/fwknop-client/
+*.obj
+*.pdb
+*.iobj
+*.ipdb
+*.lib
+*.exp
+*.recipe
+*.tlog
+*.lastbuildstate

--- a/common/common.h
+++ b/common/common.h
@@ -106,17 +106,21 @@
   #define S_IRUSR		_S_IREAD
   #define S_IWUSR		_S_IWRITE
   #define PATH_SEP      '\\'
-  // --DSS needed for VS versions before 2010
-  #ifndef __MINGW32__
-    typedef __int8 int8_t;
+  // Needed for VS versions before 2010 (VS2010+ has stdint.h)
+  #if defined(_MSC_VER) && _MSC_VER < 1600
+    #ifndef __MINGW32__
+      typedef __int8 int8_t;
+    #endif
+    typedef unsigned __int8 uint8_t;
+    typedef __int16 int16_t;
+    typedef unsigned __int16 uint16_t;
+    typedef __int32 int32_t;
+    typedef unsigned __int32 uint32_t;
+    typedef __int64 int64_t;
+    typedef unsigned __int64 uint64_t;
+  #else
+    #include <stdint.h>
   #endif
-  typedef unsigned __int8 uint8_t;
-  typedef __int16 int16_t;
-  typedef unsigned __int16 uint16_t;
-  typedef __int32 int32_t;
-  typedef unsigned __int32 uint32_t;
-  typedef __int64 int64_t;
-  typedef unsigned __int64 uint64_t;
 
 #else
   #include <signal.h>

--- a/win32/fwknop-client.vcxproj
+++ b/win32/fwknop-client.vcxproj
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}</ProjectGuid>
+    <RootNamespace>fwknop-client</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\client;$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\client;$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_WIN64;_DEBUG;_CONSOLE;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\client;$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_WIN64;NDEBUG;_CONSOLE;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\client;$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\client\config_init.c" />
+    <ClCompile Include="..\client\fwknop.c" />
+    <ClCompile Include="..\client\getpasswd.c" />
+    <ClCompile Include="..\client\http_resolve_host.c" />
+    <ClCompile Include="..\client\log_msg.c" />
+    <ClCompile Include="..\client\spa_comm.c" />
+    <ClCompile Include="..\client\utils.c" />
+    <ClCompile Include="..\common\fko_util.c" />
+    <ClCompile Include="..\common\strlcat.c" />
+    <ClCompile Include="..\common\strlcpy.c" />
+    <ClCompile Include="getopt.c" />
+    <ClCompile Include="getopt1.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\client\cmd_opts.h" />
+    <ClInclude Include="..\common\common.h" />
+    <ClInclude Include="config.h" />
+    <ClInclude Include="..\client\config_init.h" />
+    <ClInclude Include="..\lib\fko.h" />
+    <ClInclude Include="..\common\fko_util.h" />
+    <ClInclude Include="..\client\fwknop.h" />
+    <ClInclude Include="..\client\fwknop_common.h" />
+    <ClInclude Include="getopt.h" />
+    <ClInclude Include="..\client\getpasswd.h" />
+    <ClInclude Include="..\client\log_msg.h" />
+    <ClInclude Include="..\common\netinet_common.h" />
+    <ClInclude Include="..\client\spa_comm.h" />
+    <ClInclude Include="..\client\utils.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="libfko.vcxproj">
+      <Project>{133BC195-4877-481D-9F56-9F1BEBAD21F0}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/win32/libfko.sln
+++ b/win32/libfko.sln
@@ -1,6 +1,8 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libfko", "libfko.vcxproj", "{133BC195-4877-481D-9F56-9F1BEBAD21F0}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fwknop-client", "fwknop-client.vcxproj", "{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}"
@@ -8,32 +10,27 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
-		Debug-static|Win32 = Debug-static|Win32
 		Release|Win32 = Release|Win32
-		Release-full-static|Win32 = Release-full-static|Win32
-		Release-static|Win32 = Release-static|Win32
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Debug|Win32.ActiveCfg = Debug|Win32
 		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Debug|Win32.Build.0 = Debug|Win32
-		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Debug-static|Win32.ActiveCfg = Debug-static|Win32
-		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Debug-static|Win32.Build.0 = Debug-static|Win32
 		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release|Win32.ActiveCfg = Release|Win32
 		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release|Win32.Build.0 = Release|Win32
-		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release-full-static|Win32.ActiveCfg = Release-full-static|Win32
-		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release-full-static|Win32.Build.0 = Release-full-static|Win32
-		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release-static|Win32.ActiveCfg = Release-static|Win32
-		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release-static|Win32.Build.0 = Release-static|Win32
+		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Debug|x64.ActiveCfg = Debug|x64
+		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Debug|x64.Build.0 = Debug|x64
+		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release|x64.ActiveCfg = Release|x64
+		{133BC195-4877-481D-9F56-9F1BEBAD21F0}.Release|x64.Build.0 = Release|x64
 		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Debug|Win32.Build.0 = Debug|Win32
-		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Debug-static|Win32.ActiveCfg = Debug-static|Win32
-		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Debug-static|Win32.Build.0 = Debug-static|Win32
 		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release|Win32.ActiveCfg = Release|Win32
 		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release|Win32.Build.0 = Release|Win32
-		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release-full-static|Win32.ActiveCfg = Release-full-static|Win32
-		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release-full-static|Win32.Build.0 = Release-full-static|Win32
-		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release-static|Win32.ActiveCfg = Release-static|Win32
-		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release-static|Win32.Build.0 = Release-static|Win32
+		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Debug|x64.ActiveCfg = Debug|x64
+		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Debug|x64.Build.0 = Debug|x64
+		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release|x64.ActiveCfg = Release|x64
+		{D8AFA02D-14BF-42F4-97DE-EF4924D046D6}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/win32/libfko.vcxproj
+++ b/win32/libfko.vcxproj
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{133BC195-4877-481D-9F56-9F1BEBAD21F0}</ProjectGuid>
+    <RootNamespace>libfko</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v145</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Lib>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_WIN64;_DEBUG;_LIB;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_WIN64;NDEBUG;_LIB;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)..\lib;$(ProjectDir)..\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Lib>
+      <LinkTimeCodeGeneration>true</LinkTimeCodeGeneration>
+    </Lib>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\lib\base64.c" />
+    <ClCompile Include="..\lib\cipher_funcs.c" />
+    <ClCompile Include="..\lib\digest.c" />
+    <ClCompile Include="..\lib\fko_client_timeout.c" />
+    <ClCompile Include="..\lib\fko_decode.c" />
+    <ClCompile Include="..\lib\fko_digest.c" />
+    <ClCompile Include="..\lib\fko_encode.c" />
+    <ClCompile Include="..\lib\fko_encryption.c" />
+    <ClCompile Include="..\lib\fko_error.c" />
+    <ClCompile Include="..\lib\fko_funcs.c" />
+    <ClCompile Include="..\lib\fko_hmac.c" />
+    <ClCompile Include="..\lib\fko_message.c" />
+    <ClCompile Include="..\lib\fko_nat_access.c" />
+    <ClCompile Include="..\lib\fko_rand_value.c" />
+    <ClCompile Include="..\lib\fko_server_auth.c" />
+    <ClCompile Include="..\lib\fko_timestamp.c" />
+    <ClCompile Include="..\lib\fko_user.c" />
+    <ClCompile Include="..\lib\gpgme_funcs.c" />
+    <ClCompile Include="..\lib\hmac.c" />
+    <ClCompile Include="..\lib\md5.c" />
+    <ClCompile Include="..\lib\rijndael.c" />
+    <ClCompile Include="..\lib\sha1.c" />
+    <ClCompile Include="..\lib\sha2.c" />
+    <ClCompile Include="..\lib\sha3.c" />
+    <ClCompile Include="..\common\fko_util.c" />
+    <ClCompile Include="..\common\strlcat.c" />
+    <ClCompile Include="..\common\strlcpy.c" />
+    <ClCompile Include="getlogin.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\lib\base64.h" />
+    <ClInclude Include="..\lib\cipher_funcs.h" />
+    <ClInclude Include="..\common\common.h" />
+    <ClInclude Include="config.h" />
+    <ClInclude Include="..\lib\digest.h" />
+    <ClInclude Include="..\lib\fko.h" />
+    <ClInclude Include="..\lib\fko_common.h" />
+    <ClInclude Include="..\lib\fko_context.h" />
+    <ClInclude Include="..\lib\fko_limits.h" />
+    <ClInclude Include="..\lib\fko_state.h" />
+    <ClInclude Include="..\common\fko_util.h" />
+    <ClInclude Include="getlogin.h" />
+    <ClInclude Include="..\lib\gpgme_funcs.h" />
+    <ClInclude Include="..\lib\hmac.h" />
+    <ClInclude Include="..\lib\md5.h" />
+    <ClInclude Include="..\lib\rijndael.h" />
+    <ClInclude Include="..\lib\sha1.h" />
+    <ClInclude Include="..\lib\sha2.h" />
+    <ClInclude Include="..\lib\sha3.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
Creates win32/libfko.vcxproj and win32/fwknop-client.vcxproj (v145 toolset, Win32/x64 Debug/Release) so the fwknop client and libfko can be built natively on Windows without Cygwin. Updates libfko.sln to VS2022+ format. Fixes common/common.h to include <stdint.h> on VS2010+ instead of redefining the fixed-width integer types. Adds MSVC build artifacts to .gitignore.